### PR TITLE
INF-4857: Add support for templating .tf.j2 files in definitions

### DIFF
--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -47,7 +47,7 @@ def validate_gcp_creds_path(ctx, path, value):
 def validate_host():
     """Ensure that the script is being run on a supported platform."""
     supported_opsys = ["darwin", "linux"]
-    supported_machine = ["amd64","arm64"]
+    supported_machine = ["amd64", "arm64"]
 
     opsys, machine = get_platform()
 

--- a/tfworker/commands/base.py
+++ b/tfworker/commands/base.py
@@ -89,7 +89,9 @@ class BaseCommand:
             try:
                 raw_version = rootc.providers_odict[provider]["requirements"]["version"]
             except KeyError:
-                click.secho("providers must have a version constraint specified", fg="red")
+                click.secho(
+                    "providers must have a version constraint specified", fg="red"
+                )
                 raise SystemExit()
             version = raw_version.split(" ")[-1]
             vals = {"version": version}

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -113,7 +113,7 @@ class TerraformCommand(BaseCommand):
             # copy definition files / templates etc.
             click.secho(f"preparing definition: {definition.tag}", fg="green")
             definition.prep(
-                self._backend,
+                self._backend
             )
             # run terraform init
             try:

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -65,7 +65,9 @@ class TerraformCommand(BaseCommand):
     def prep_modules(self):
         """Puts the modules sub directories into place."""
 
-        click.secho(f"DEBUG: terraform_modules_dir: {self._terraform_modules_dir}", fg="red")
+        click.secho(
+            f"DEBUG: terraform_modules_dir: {self._terraform_modules_dir}", fg="red"
+        )
         if self._terraform_modules_dir:
             mod_source = self._terraform_modules_dir
             mod_path = pathlib.Path(mod_source)
@@ -112,9 +114,7 @@ class TerraformCommand(BaseCommand):
             plan_file = None
             # copy definition files / templates etc.
             click.secho(f"preparing definition: {definition.tag}", fg="green")
-            definition.prep(
-                self._backend
-            )
+            definition.prep(self._backend)
             # run terraform init
             try:
                 self._run(definition, "init", debug=self._show_output)
@@ -126,9 +126,13 @@ class TerraformCommand(BaseCommand):
             if self._plan_file_path:
                 plan_path = pathlib.Path.absolute(pathlib.Path(self._plan_file_path))
                 if not (plan_path.exists() and plan_path.is_dir()):
-                    click.secho(f"plan path \"{plan_path}\" is not suitable, it is not an existing directory")
+                    click.secho(
+                        f'plan path "{plan_path}" is not suitable, it is not an existing directory'
+                    )
                     raise SystemExit()
-                plan_file = pathlib.Path(f"{plan_path}/{self._deployment}_{definition.tag}.tfplan")
+                plan_file = pathlib.Path(
+                    f"{plan_path}/{self._deployment}_{definition.tag}.tfplan"
+                )
                 click.secho(f"using plan file:{plan_file}", fg="yellow")
 
             # check if a plan file for the given deployment/definition exists, if so
@@ -153,7 +157,7 @@ class TerraformCommand(BaseCommand):
                         "plan",
                         debug=self._show_output,
                         plan_action=self._plan_for,
-                        plan_file=str(plan_file)
+                        plan_file=str(plan_file),
                     )
                 except PlanChange:
                     # on destroy, terraform ALWAYS indicates a plan change
@@ -188,7 +192,7 @@ class TerraformCommand(BaseCommand):
                     definition,
                     self._plan_for,
                     debug=self._show_output,
-                    plan_file = str(plan_file)
+                    plan_file=str(plan_file),
                 )
             except TerraformError:
                 click.secho(
@@ -209,7 +213,9 @@ class TerraformCommand(BaseCommand):
                     # plan file succeeded and has been consumed
                     plan_file.unlink()
 
-    def _run(self, definition, command, debug=False, plan_action="init", plan_file=None):
+    def _run(
+        self, definition, command, debug=False, plan_action="init", plan_file=None
+    ):
         """Run terraform."""
         if self._tf_version_major >= 12:
             params = {


### PR DESCRIPTION
This allows for jinja templating in terraform, for example the following block: 

```
module "affinipay_com" {
{% if var.use_dev is defined and var.use_dev == "true" %}
  {% if var.test_branch is defined and var.test_branch is not none %}
    source = "git@bitbucket.org:affinipay/tf-module-eks-service-role.git?ref={{ var.test_branch }}"
  {% else %}
    source = "../../terraform-modules/tf-module-dns-zone"
  {% endif %}
{% else %}
  source = "git@bitbucket.org:affinipay/tf-module-eks-service-role.git?ref=rel/1.0"
{% endif %}

  name    = "affinirmaynardtest.com"
  records = local.affinipay_com_dns_records
}
```

Would allow the worker to be passed --config-var use_dev=true and use local terraform files instead of trying to pull the remote module. As with the worker config rendering all environment variables are also available as env.ENV_VAR in templates.