### PR TITLE
INF-4840: resolve issues with provider cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 .coverage
 htmlcov
 .pytest_cache
+registry.terraform.io/

--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -96,7 +96,7 @@ class TestTerraformCommand:
             (
                 "destroy",
                 lazy_fixture("tf_12cmd"),
-                ["-input=false", "-no-color", "-force"],
+                ["-input=false", "-no-color", "-auto-approve"],
             ),
             (
                 "init",
@@ -116,7 +116,7 @@ class TestTerraformCommand:
             (
                 "destroy",
                 lazy_fixture("tf_13cmd"),
-                ["-input=false", "-no-color", "-force"],
+                ["-input=false", "-no-color", "-auto-approve"],
             ),
             (
                 "init",
@@ -136,7 +136,7 @@ class TestTerraformCommand:
             (
                 "destroy",
                 lazy_fixture("tf_14cmd"),
-                ["-input=false", "-no-color", "-force"],
+                ["-input=false", "-no-color", "-auto-approve"],
             ),
             (
                 "init",

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -56,6 +56,7 @@ class TestDefinitions:
             (12, EXPECTED_TF_BLOCK, ["aws", "google", "google_beta", "null", "vault"]),
         ],
     )
+    @pytest.mark.skip(reason="TF version handling has changed significantly, rewrite.")
     def test_prep(self, basec, tf_version, expected_tf_block, expected_providers):
         definition = basec.definitions["test"]
         definition._tf_version_major = tf_version

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -71,13 +71,13 @@ class TestPlugins:
     @pytest.mark.depends(on="get_url")
     def test_plugin_download(self, rootc):
         plugins = tfworker.plugins.PluginsCollection(
-            {"null": {"version": "3.2.1"}}, rootc.temp_dir, 12
+            {"null": {"version": "3.2.1"}}, rootc.temp_dir, None, 1
         )
         plugins.download()
         files = glob.glob(
-            f"{rootc.temp_dir}/terraform-plugins/terraform-provider-null_v3.2.1*"
+            f"{rootc.temp_dir}/terraform-plugins/registry.terraform.io/hashicorp/null/*null*3.2.1*.zip"
         )
-        assert len(files) > 0
+        assert len(files) == 1
         for afile in files:
             assert os.path.isfile(afile)
             assert (os.stat(afile).st_mode & 0o777) == 0o755

--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -162,15 +162,18 @@ def validate_working_dir(fpath):
 @click.option(
     "--backend",
     type=click.Choice(["s3", "gcs"]),
+    envvar="WORKER_BACKEND",
     help="State/locking provider. One of: s3, gcs",
 )
 @click.option(
     "--backend-bucket",
+    envvar="WORKER_BACKEND_BUCKET",
     help="Bucket (must exist) where all terraform states are stored",
 )
 @click.option(
     "--backend-prefix",
     default=const.DEFAULT_BACKEND_PREFIX,
+    envvar="WORKER_BACKEND_PREFIX",
     help=f"Prefix to use in backend storage bucket for all terraform states (DEFAULT: {const.DEFAULT_BACKEND_PREFIX})",
 )
 @click.option(
@@ -191,12 +194,14 @@ def validate_working_dir(fpath):
 )
 @click.option(
     "--working-dir",
+    envvar="WORKER_WORKING_DIR",
     default=None,
     help="Specify the path to use instead of a temporary directory, must exist, be empty, and be writeable, --clean applies to this directory as well",
 )
 @click.option(
     "--clean/--no-clean",
     default=None,
+    envvar="WORKER_CLEAN",
     help="clean up the temporary directory created by the worker after execution",
 )
 @click.pass_context
@@ -213,7 +218,12 @@ def cli(context, **kwargs):
 
 
 @cli.command()
-@click.option("--limit", help="limit operations to a single definition", multiple=True)
+@click.option(
+    "--limit",
+    help="limit operations to a single definition",
+    envvar="WORKER_LIMIT",
+    multiple=True,
+)
 @click.argument("deployment", callback=validate_deployment)
 @click.pass_obj
 def clean(rootc, *args, **kwargs):  # noqa: E501
@@ -233,17 +243,20 @@ def version():
 @click.option(
     "--plan-file-path",
     default=None,
+    envvar="WORKER_PLAN_FILE_PATH",
     help="path to plan files, with plan it will save to this location, apply will read from it",
 )
 @click.option(
     "--apply/--no-apply",
     "tf_apply",
+    envvar="WORKER_APPLY",
     default=False,
     help="apply the terraform configuration",
 )
 @click.option(
     "--plan/--no-plan",
     "tf_plan",
+    envvar="WORKER_PLAN",
     default=True,
     help="toggle running a plan, plan will still be skipped if using a saved plan file with apply",
 )
@@ -251,26 +264,31 @@ def version():
     "--force/--no-force",
     "force",
     default=False,
+    envvar="WORKER_FORCE",
     help="force apply/destroy without plan change",
 )
 @click.option(
     "--destroy/--no-destroy",
     default=False,
+    envvar="WORKER_DESTROY",
     help="destroy a deployment instead of create it",
 )
 @click.option(
     "--show-output/--no-show-output",
     default=True,
+    envvar="WORKER_SHOW_OUTPUT",
     help="show output from terraform commands",
 )
 @click.option(
     "--terraform-bin",
+    envvar="WORKER_TERRAFORM_BIN",
     help="The complate location of the terraform binary",
 )
 @click.option(
     "--b64-encode-hook-values/--no--b64-encode-hook-values",
     "b64_encode",
     default=False,
+    envvar="WORKER_B64_ENCODE_HOOK_VALUES",
     help=(
         "Terraform variables and outputs can be complex data structures, setting this"
         " open will base64 encode the values for use in hook scripts"
@@ -278,6 +296,7 @@ def version():
 )
 @click.option(
     "--terraform-modules-dir",
+    envvar="WORKER_TERRAFORM_MODULES_DIR",
     default="",
     help=(
         "Absolute path to the directory where terraform modules will be stored."
@@ -285,7 +304,13 @@ def version():
     ),
 )
 @click.option("--limit", help="limit operations to a single definition", multiple=True)
-@click.argument("deployment", callback=validate_deployment)
+@click.option(
+    "--provider-cache",
+    envvar="WORKER_PROVIDER_CACHE",
+    default=None,
+    help="if provided this directory will be used as a cache for provider plugins",
+)
+@click.argument("deployment", envvar="WORKER_DEPLOYMENT", callback=validate_deployment)
 @click.pass_obj
 def terraform(rootc, *args, **kwargs):
     """ execute terraform orchestration """
@@ -295,7 +320,7 @@ def terraform(rootc, *args, **kwargs):
     click.secho(f"using temporary Directory: {tfc.temp_dir}", fg="yellow")
 
     # common setup required for all definitions
-    click.secho("downloading plugins", fg="green")
+    click.secho("preparing provider plugins", fg="green")
     tfc.plugins.download()
     click.secho("preparing modules", fg="green")
     tfc.prep_modules()

--- a/tfworker/commands/base.py
+++ b/tfworker/commands/base.py
@@ -48,6 +48,8 @@ class BaseCommand:
         rootc.add_arg("deployment", deployment)
         rootc.load_config()
 
+        self._provider_cache = self._resolve_arg("provider_cache")
+
         (self._tf_version_major, self._tf_version_minor) = self._resolve_arg(
             "tf_version"
         ) or (None, None)
@@ -101,7 +103,7 @@ class BaseCommand:
                 vals["source"] = source
             plugins_odict[str(provider)] = vals
         self._plugins = PluginsCollection(
-            plugins_odict, self._temp_dir, self._tf_version_major
+            plugins_odict, self._temp_dir, self._provider_cache, self._tf_version_major
         )
         self._backend = select_backend(
             self._resolve_arg("backend"),

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -213,22 +213,12 @@ class TerraformCommand(BaseCommand):
         self, definition, command, debug=False, plan_action="init", plan_file=None
     ):
         """Run terraform."""
-        if self._tf_version_major >= 12:
-            params = {
-                "init": f"-input=false -no-color -plugin-dir={self._temp_dir}/terraform-plugins",
-                "plan": "-input=false -detailed-exitcode -no-color",
-                "apply": "-input=false -no-color -auto-approve",
-                "destroy": "-input=false -no-color -force",
-            }
-            if self._tf_version_major >= 15:
-                params["destroy"] = "-input=false -no-color -auto-approve"
-        else:
-            params = {
-                "init": "-input=false -no-color",
-                "plan": "-input=false -detailed-exitcode -no-color",
-                "apply": "-input=false -no-color -auto-approve",
-                "destroy": "-input=false -no-color -force",
-            }
+        params = {
+            "init": f"-input=false -no-color -plugin-dir={self._temp_dir}/terraform-plugins",
+            "plan": "-input=false -detailed-exitcode -no-color",
+            "apply": "-input=false -no-color -auto-approve",
+            "destroy": "-input=false -no-color -auto-approve",
+        }
 
         if plan_action == "destroy":
             params["plan"] += " -destroy"
@@ -241,7 +231,7 @@ class TerraformCommand(BaseCommand):
         for auth in self._authenticators:
             env.update(auth.env())
 
-        env["TF_PLUGIN_CACHE_DIR"] = f"{self._temp_dir}/terraform-plugins"
+        # env["TF_PLUGIN_CACHE_DIR"] = f"{self._temp_dir}/terraform-plugins"
 
         working_dir = f"{self._temp_dir}/definitions/{definition.tag}"
         command_params = params.get(command)


### PR DESCRIPTION
- add registry.terraform.io to .gitignore, created during tests
- skip definition prep tests, they are currently broken due to dropping tf < 1 support
- update tests to validate new plugin logic
- add environment variable configuration ability for most options
- implement --provider-cache option to specify a persistent directory for providers
- remove bad logic that was generating unexpected terraform arguments in exec
- update plugins collection to support checking for items in cache
- update plugins collection to support terraform 1.3+ directory structure
- update plugins test to support new mechanisms for plugins
- decreased fixed wait times on plugin download attempts to account for interactive use case