### PR TITLE
INF-4932: add env command

### DIFF
--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -23,6 +23,7 @@ import click
 
 from tfworker import constants as const
 from tfworker.commands import CleanCommand, RootCommand, TerraformCommand
+from tfworker.commands.env import EnvCommand
 from tfworker.commands.root import get_platform
 from tfworker.commands.version import VersionCommand
 
@@ -326,6 +327,15 @@ def terraform(rootc, *args, **kwargs):
     tfc.prep_modules()
 
     tfc.exec()
+    sys.exit(0)
+
+
+@cli.command()
+@click.pass_obj
+def env(rootc, *args, **kwargs):
+    # provide environment variables from backend to configure shell environment
+    env = EnvCommand(rootc, *args, **kwargs)
+    env.exec()
     sys.exit(0)
 
 

--- a/tfworker/commands/env.py
+++ b/tfworker/commands/env.py
@@ -1,0 +1,24 @@
+import click
+
+from tfworker.authenticators import AuthenticatorsCollection
+
+
+class EnvCommand:
+    """
+    The env command translates the environment configuration that is used for the worker
+    into an output that can be `eval`'d by a shell. This will allow one to maintain the
+    same authentication options that the worker will use when running terraform when
+    executing commands against the rendered terraform definitions such as `terraform import`
+    """
+
+    def __init__(self, rootc, **kwargs):
+        # parse the configuration
+        rootc.load_config()
+
+        # initialize any authenticators
+        self._authenticators = AuthenticatorsCollection(rootc.args, deployment=None)
+
+    def exec(self):
+        for auth in self._authenticators:
+            for k, v in auth.env().items():
+                click.secho(f"export {k}={v}")


### PR DESCRIPTION
add support for an `env` command which will resolve the authentication options and provide the environment configuration that can be imported into a shell