### PR TITLE
INF-4935: streaming output

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1390,6 +1390,21 @@ files = [
 pytest = ">=3.2.5"
 
 [[package]]
+name = "pytest-timeout"
+version = "2.1.0"
+description = "pytest plugin to abort hanging tests"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pytest-timeout-2.1.0.tar.gz", hash = "sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9"},
+    {file = "pytest_timeout-2.1.0-py3-none-any.whl", hash = "sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6"},
+]
+
+[package.dependencies]
+pytest = ">=5.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -2020,4 +2035,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "04dfe20cb4f2282a65216b5b1a554f961d807817ca17838c966f8eee14cbc6d1"
+content-hash = "e68049eae1d997f4a8471d1f039e23073e663af1064562ea15aee2a1c5a827e4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ deepdiff = "^5.3.0"
 [tool.poetry.scripts]
 worker = 'tfworker.cli:cli'
 
+[tool.poetry.group.dev.dependencies]
+pytest-timeout = "2.1.0"
+
 [tool.pytest.ini_options]
 addopts = "--capture=sys --cov=tfworker --cov-report="
 

--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -34,7 +34,7 @@ def does_not_raise():
     yield
 
 
-def mock_pipe_exec(args: str, stdin: str = None, cwd: str = None, env: list = None):
+def mock_pipe_exec(args: str, stdin: str = None, cwd: str = None, env: list = None, stream_output: bool = False):
     return (0, "".encode(), "".encode())
 
 

--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -34,7 +34,13 @@ def does_not_raise():
     yield
 
 
-def mock_pipe_exec(args: str, stdin: str = None, cwd: str = None, env: list = None, stream_output: bool = False):
+def mock_pipe_exec(
+    args: str,
+    stdin: str = None,
+    cwd: str = None,
+    env: list = None,
+    stream_output: bool = False,
+):
     return (0, "".encode(), "".encode())
 
 

--- a/tests/util/test_system.py
+++ b/tests/util/test_system.py
@@ -55,7 +55,7 @@ class TestUtilSystem:
                 None,
                 "",
                 "/bin/cat: /yisohwo0AhK8Ah: No such file or directory",
-                False
+                False,
             ),
             (
                 "/bin/cat /yisohwo0AhK8Ah ",
@@ -64,10 +64,26 @@ class TestUtilSystem:
                 None,
                 "",
                 "/bin/cat: /yisohwo0AhK8Ah: No such file or directory",
-                True
+                True,
             ),
-            (["/bin/echo foo", "/usr/bin/env grep foo"], 0, None, None, "foo", "", False),
-            (["/bin/echo foo", "/usr/bin/env grep foo"], 0, None, None, "foo", "", True),
+            (
+                ["/bin/echo foo", "/usr/bin/env grep foo"],
+                0,
+                None,
+                None,
+                "foo",
+                "",
+                False,
+            ),
+            (
+                ["/bin/echo foo", "/usr/bin/env grep foo"],
+                0,
+                None,
+                None,
+                "foo",
+                "",
+                True,
+            ),
             (["/bin/echo foo", "/usr/bin/env grep bar"], 1, None, None, "", "", False),
             (["/bin/echo foo", "/usr/bin/env grep bar"], 1, None, None, "", "", True),
             (["/bin/cat", "/usr/bin/env grep foo"], 0, None, "foo", "foo", "", False),
@@ -75,7 +91,9 @@ class TestUtilSystem:
         ],
     )
     @pytest.mark.timeout(2)
-    def test_pipe_exec(self, commands, exit_code, cwd, stdin, stdout, stderr, stream_output):
+    def test_pipe_exec(
+        self, commands, exit_code, cwd, stdin, stdout, stderr, stream_output
+    ):
         (return_exit_code, return_stdout, return_stderr) = pipe_exec(
             commands, cwd=cwd, stdin=stdin, stream_output=stream_output
         )

--- a/tests/util/test_system.py
+++ b/tests/util/test_system.py
@@ -36,13 +36,18 @@ def mock_tf_version(args: str):
 
 class TestUtilSystem:
     @pytest.mark.parametrize(
-        "commands, exit_code, cwd, stdin, stdout, stderr",
+        "commands, exit_code, cwd, stdin, stdout, stderr, stream_output",
         [
-            ("/usr/bin/env true", 0, None, None, "", ""),
-            ("/usr/bin/env false", 1, None, None, "", ""),
-            ("/bin/echo foo", 0, None, None, "foo", ""),
-            ("/usr/bin/env grep foo", 0, None, "foo", "foo", ""),
-            ("/bin/pwd", 0, "/tmp", None, "/tmp", ""),
+            ("/usr/bin/env true", 0, None, None, "", "", False),
+            ("/usr/bin/env true", 0, None, None, "", "", True),
+            ("/usr/bin/env false", 1, None, None, "", "", False),
+            ("/usr/bin/env false", 1, None, None, "", "", True),
+            ("/bin/echo foo", 0, None, None, "foo", "", False),
+            ("/bin/echo foo", 0, None, None, "foo", "", True),
+            ("/usr/bin/env grep foo", 0, None, "foo", "foo", "", False),
+            ("/usr/bin/env grep foo", 0, None, "foo", "foo", "", True),
+            ("/bin/pwd", 0, "/tmp", None, "/tmp", "", False),
+            ("/bin/pwd", 0, "/tmp", None, "/tmp", "", True),
             (
                 "/bin/cat /yisohwo0AhK8Ah ",
                 1,
@@ -50,15 +55,29 @@ class TestUtilSystem:
                 None,
                 "",
                 "/bin/cat: /yisohwo0AhK8Ah: No such file or directory",
+                False
             ),
-            (["/bin/echo foo", "/usr/bin/env grep foo"], 0, None, None, "foo", ""),
-            (["/bin/echo foo", "/usr/bin/env grep bar"], 1, None, None, "", ""),
-            (["/bin/cat", "/usr/bin/env grep foo"], 0, None, "foo", "foo", ""),
+            (
+                "/bin/cat /yisohwo0AhK8Ah ",
+                1,
+                None,
+                None,
+                "",
+                "/bin/cat: /yisohwo0AhK8Ah: No such file or directory",
+                True
+            ),
+            (["/bin/echo foo", "/usr/bin/env grep foo"], 0, None, None, "foo", "", False),
+            (["/bin/echo foo", "/usr/bin/env grep foo"], 0, None, None, "foo", "", True),
+            (["/bin/echo foo", "/usr/bin/env grep bar"], 1, None, None, "", "", False),
+            (["/bin/echo foo", "/usr/bin/env grep bar"], 1, None, None, "", "", True),
+            (["/bin/cat", "/usr/bin/env grep foo"], 0, None, "foo", "foo", "", False),
+            (["/bin/cat", "/usr/bin/env grep foo"], 0, None, "foo", "foo", "", True),
         ],
     )
-    def test_pipe_exec(self, commands, exit_code, cwd, stdin, stdout, stderr):
+    @pytest.mark.timeout(2)
+    def test_pipe_exec(self, commands, exit_code, cwd, stdin, stdout, stderr, stream_output):
         (return_exit_code, return_stdout, return_stderr) = pipe_exec(
-            commands, cwd=cwd, stdin=stdin
+            commands, cwd=cwd, stdin=stdin, stream_output=stream_output
         )
 
         assert return_exit_code == exit_code

--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -311,6 +311,7 @@ def version():
     default=None,
     help="if provided this directory will be used as a cache for provider plugins",
 )
+@click.option("--stream-output/--no-stream-output", help="stream the output from terraform command", envvar="WORKER_STREAM_OUTPUT", default=True)
 @click.argument("deployment", envvar="WORKER_DEPLOYMENT", callback=validate_deployment)
 @click.pass_obj
 def terraform(rootc, *args, **kwargs):

--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -311,7 +311,12 @@ def version():
     default=None,
     help="if provided this directory will be used as a cache for provider plugins",
 )
-@click.option("--stream-output/--no-stream-output", help="stream the output from terraform command", envvar="WORKER_STREAM_OUTPUT", default=True)
+@click.option(
+    "--stream-output/--no-stream-output",
+    help="stream the output from terraform command",
+    envvar="WORKER_STREAM_OUTPUT",
+    default=True,
+)
 @click.argument("deployment", envvar="WORKER_DEPLOYMENT", callback=validate_deployment)
 @click.pass_obj
 def terraform(rootc, *args, **kwargs):

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -231,8 +231,6 @@ class TerraformCommand(BaseCommand):
         for auth in self._authenticators:
             env.update(auth.env())
 
-        # env["TF_PLUGIN_CACHE_DIR"] = f"{self._temp_dir}/terraform-plugins"
-
         working_dir = f"{self._temp_dir}/definitions/{definition.tag}"
         command_params = params.get(command)
         if not command_params:
@@ -276,6 +274,7 @@ class TerraformCommand(BaseCommand):
             f"{self._terraform_bin} {command} {command_params}",
             cwd=working_dir,
             env=env,
+            stream_output=True
         )
         if debug:
             click.secho(f"exit code: {exit_code}", fg="blue")

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -53,6 +53,9 @@ class TerraformCommand(BaseCommand):
         self._deployment = kwargs["deployment"]
         self._force = self._resolve_arg("force")
         self._show_output = self._resolve_arg("show_output")
+        # streaming doesn't allow for distinction between stderr and stdout, but allows
+        # terraform operations to be viewed before the process is completed
+        self._stream_output = self._resolve_arg("stream_output")
         self._terraform_modules_dir = self._resolve_arg("terraform_modules_dir")
 
     @property
@@ -274,10 +277,10 @@ class TerraformCommand(BaseCommand):
             f"{self._terraform_bin} {command} {command_params}",
             cwd=working_dir,
             env=env,
-            stream_output=True
+            stream_output=self._stream_output
         )
-        if debug:
-            click.secho(f"exit code: {exit_code}", fg="blue")
+        click.secho(f"exit code: {exit_code}", fg="blue")
+        if debug and not self._stream_output:
             for line in stdout.decode().splitlines():
                 click.secho(f"stdout: {line}", fg="blue")
             for line in stderr.decode().splitlines():

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -280,11 +280,24 @@ class TerraformCommand(BaseCommand):
             stream_output=self._stream_output,
         )
         click.secho(f"exit code: {exit_code}", fg="blue")
+
         if debug and not self._stream_output:
             for line in stdout.decode().splitlines():
                 click.secho(f"stdout: {line}", fg="blue")
             for line in stderr.decode().splitlines():
                 click.secho(f"stderr: {line}", fg="red")
+
+        # If a plan file was saved, write the plan output
+        if plan_file is not None:
+            plan_log = f"{os.path.splitext(plan_file)[0]}.log"
+
+            with open(plan_log, 'w') as pl:
+                pl.write("STDOUT:\n")
+                for line in stdout.decode().splitlines():
+                    pl.write(f"{line}\n")
+                pl.write("\nSTDERR:\n")
+                for line in stderr.decode().splitlines():
+                    pl.write(f"{line}\n")
 
         # special handling of the exit codes for "plan" operations
         if command == "plan":

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -277,7 +277,7 @@ class TerraformCommand(BaseCommand):
             f"{self._terraform_bin} {command} {command_params}",
             cwd=working_dir,
             env=env,
-            stream_output=self._stream_output
+            stream_output=self._stream_output,
         )
         click.secho(f"exit code: {exit_code}", fg="blue")
         if debug and not self._stream_output:

--- a/tfworker/util/system.py
+++ b/tfworker/util/system.py
@@ -14,15 +14,18 @@
 import os
 import shlex
 import subprocess
+import click
 
 
-def pipe_exec(args, stdin=None, cwd=None, env=None):
+### FIRST COMMAND IN PIPE NOT GETTING STDIN INPUT :(
+
+
+def pipe_exec(args, stdin=None, cwd=None, env=None, stream_output=False):
     """
     A function to accept a list of commands and pipe them together.
 
     Takes optional stdin to give to the first item in the pipe chain.
     """
-    count = 0  # int used to manage communication between processes
     commands = []  # listed used to hold all the popen objects
 
     # use the default environment if one is not specified
@@ -42,29 +45,81 @@ def pipe_exec(args, stdin=None, cwd=None, env=None):
     }
     popen_stdin_kwargs = {}
     communicate_kwargs = {}
+
+    if stream_output is True:
+        popen_kwargs["bufsize"] = 1
+        popen_kwargs["universal_newlines"] = True
+
     if stdin is not None:
         popen_stdin_kwargs["stdin"] = subprocess.PIPE
         communicate_kwargs["input"] = stdin.encode()
 
-    # handle the first process
+    if len(args) == 1 and stream_output is True:
+        popen_kwargs["stderr"] = subprocess.STDOUT
+
+    # handle the first command, requires distinct handling
     i = args.pop(0)
     commands.append(
         subprocess.Popen(shlex.split(i), **popen_kwargs, **popen_stdin_kwargs)
     )
 
-    # handle any additional arguments
-    for i in args:
-        popen_kwargs["stdin"] = commands[count].stdout
-        commands.append(subprocess.Popen(shlex.split(i), **popen_kwargs))
-        commands[count].stdout.close()
-        count = count + 1
+    # handle any additional commands
+    # every process now gets stdin as a pipe
+    for i, cmd_str in enumerate(args):
+        lastloop = True if len(args) - 1 == i else False
+        popen_kwargs["stdin"] = commands[-1].stdout
 
-    # communicate with first command, ensure it gets any optional input
-    commands[0].communicate(**communicate_kwargs)
+        if lastloop and stream_output:
+            popen_kwargs["stderr"] = subprocess.STDOUT
 
-    # communicate with final command, which will trigger the entire pipeline
-    stdout, stderr = commands[-1].communicate()
-    returncode = commands[-1].returncode
+        commands.append(subprocess.Popen(shlex.split(args[i]), **popen_kwargs))
+
+        # close stdout on the command before we just added to allow recieving SIGPIPE
+        commands[-2].stdout.close()
+
+    if stream_output is True:
+        # in order to stream the output, stderr and stdout streams must be combined to avoid
+        # any potential blocking, for this reason the execution methods are different
+        stdout = ""
+
+        # if there is more than one command we need to use communicate on the first to send
+        # in stdin and still allowing the pipeline to properly process
+        if len(commands) > 1:
+                # communicate in this instance needs a string type object, not bytes
+                communicate_kwargs["input"] = stdin
+                commands[0].communicate(**communicate_kwargs)
+
+        else:
+            # if it's just a single command we can not use communicate or we will not be able
+            # to stream the output, so write directly to stdin
+            if stdin is not None and len(commands) == 1:
+                commands[0].stdin.write(stdin + '\n')
+                commands[0].stdin.close()
+
+        # for a single command this will be the only command, for a pipeline reading from the
+        # last command will trigger all of the commands, communicating through their pipes
+        for line in iter(commands[-1].stdout.readline,''):
+            click.secho(line.rstrip())
+            stdout += line
+
+        # for streaming output stderr will be included with stdout, there's no way to make
+        # a distinction, so stderr will always be an empty bytes object
+        stderr = "".encode()
+        stdout = stdout.encode()
+        returncode = commands[-1].poll()
+
+    else:
+        # if stdin is not None:
+        if len(commands) > 1:
+            # in this case communicate_kwargs must only be passed to the first
+            # command in the pipe, and must NOT be passed to any other as the stdout/stdin
+            # is chained between the piped commands
+            commands[0].communicate(**communicate_kwargs)
+            stdout, stderr = commands[-1].communicate()
+            returncode = commands[-1].returncode
+        else:
+            stdout, stderr = commands[0].communicate(**communicate_kwargs)
+            returncode = commands[0].returncode
 
     return (returncode, stdout, stderr)
 

--- a/tfworker/util/system.py
+++ b/tfworker/util/system.py
@@ -14,8 +14,8 @@
 import os
 import shlex
 import subprocess
-import click
 
+import click
 
 ### FIRST COMMAND IN PIPE NOT GETTING STDIN INPUT :(
 
@@ -85,20 +85,20 @@ def pipe_exec(args, stdin=None, cwd=None, env=None, stream_output=False):
         # if there is more than one command we need to use communicate on the first to send
         # in stdin and still allowing the pipeline to properly process
         if len(commands) > 1:
-                # communicate in this instance needs a string type object, not bytes
-                communicate_kwargs["input"] = stdin
-                commands[0].communicate(**communicate_kwargs)
+            # communicate in this instance needs a string type object, not bytes
+            communicate_kwargs["input"] = stdin
+            commands[0].communicate(**communicate_kwargs)
 
         else:
             # if it's just a single command we can not use communicate or we will not be able
             # to stream the output, so write directly to stdin
             if stdin is not None and len(commands) == 1:
-                commands[0].stdin.write(stdin + '\n')
+                commands[0].stdin.write(stdin + "\n")
                 commands[0].stdin.close()
 
         # for a single command this will be the only command, for a pipeline reading from the
         # last command will trigger all of the commands, communicating through their pipes
-        for line in iter(commands[-1].stdout.readline,''):
+        for line in iter(commands[-1].stdout.readline, ""):
             click.secho(line.rstrip())
             stdout += line
 

--- a/tfworker/util/system.py
+++ b/tfworker/util/system.py
@@ -17,9 +17,6 @@ import subprocess
 
 import click
 
-### FIRST COMMAND IN PIPE NOT GETTING STDIN INPUT :(
-
-
 def pipe_exec(args, stdin=None, cwd=None, env=None, stream_output=False):
     """
     A function to accept a list of commands and pipe them together.


### PR DESCRIPTION
While running long plan or apply operations it can appear "nothing is happening" if the output is not streamed. There are benefits the current method of execution and stdout/stderr handling is desirable for a pipeline or automated run, however as an interactive tool the long waiting periods with nothing happening are a poor experience.

This change also writes the output to a .log if a plan file is being generated (regardless of output method)

- update pipe_exec to include the ability to stream output
- update all tests for pipe_exec
- save plan output to logfile when saving a .tfplan file
- add pytest-timeout to dev deps to prevent tests not finishing if errors are introduced in pipe_exec
- add --stream-output option to change how terraform output is handled
