### PR TITLE
INF-4928: deep merge the j2 template values

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = boto3,botocore,click,deepdiff,google,hcl2,jinja2,lark,moto,pkg_resources,pytest,pytest_lazyfixture,tenacity,yaml
+known_third_party = boto3,botocore,click,deepdiff,google,hcl2,jinja2,lark,mergedeep,moto,pkg_resources,pytest,pytest_lazyfixture,tenacity,yaml

--- a/poetry.lock
+++ b/poetry.lock
@@ -67,24 +67,6 @@ six = "*"
 test = ["astroid", "pytest"]
 
 [[package]]
-name = "asttokens"
-version = "2.2.1"
-description = "Annotate AST trees with source code positions"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "asttokens-2.2.1-py2.py3-none-any.whl", hash = "sha256:6b0ac9e93fb0335014d382b8fa9b3afa7df546984258005da0b9e7095b3deb1c"},
-    {file = "asttokens-2.2.1.tar.gz", hash = "sha256:4622110b2a6f30b77e1473affaa97e711bc2f07d3f10848420ff1898edbe94f3"},
-]
-
-[package.dependencies]
-six = "*"
-
-[package.extras]
-test = ["astroid", "pytest"]
-
-[[package]]
 name = "attrs"
 version = "22.2.0"
 description = "Classes Without Boilerplate"
@@ -1040,6 +1022,18 @@ files = [
 ]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+description = "A deep merge function for 🐍."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
+    {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
+]
+
+[[package]]
 name = "moto"
 version = "2.3.2"
 description = "A library that allows your python tests to easily mock out the boto library"
@@ -1287,7 +1281,18 @@ category = "main"
 optional = false
 python-versions = "*"
 files = [
+    {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
+    {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
+    {file = "pyasn1-0.4.8-py2.6.egg", hash = "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00"},
+    {file = "pyasn1-0.4.8-py2.7.egg", hash = "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8"},
     {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
+    {file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"},
+    {file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7"},
+    {file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576"},
+    {file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12"},
+    {file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2"},
+    {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
+    {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
     {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
 ]
 
@@ -1300,7 +1305,18 @@ optional = false
 python-versions = "*"
 files = [
     {file = "pyasn1-modules-0.2.8.tar.gz", hash = "sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e"},
+    {file = "pyasn1_modules-0.2.8-py2.4.egg", hash = "sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199"},
+    {file = "pyasn1_modules-0.2.8-py2.5.egg", hash = "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"},
+    {file = "pyasn1_modules-0.2.8-py2.6.egg", hash = "sha256:a99324196732f53093a84c4369c996713eb8c89d360a496b599fb1a9c47fc3eb"},
+    {file = "pyasn1_modules-0.2.8-py2.7.egg", hash = "sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8"},
     {file = "pyasn1_modules-0.2.8-py2.py3-none-any.whl", hash = "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74"},
+    {file = "pyasn1_modules-0.2.8-py3.1.egg", hash = "sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d"},
+    {file = "pyasn1_modules-0.2.8-py3.2.egg", hash = "sha256:b80486a6c77252ea3a3e9b1e360bc9cf28eaac41263d173c032581ad2f20fe45"},
+    {file = "pyasn1_modules-0.2.8-py3.3.egg", hash = "sha256:65cebbaffc913f4fe9e4808735c95ea22d7a7775646ab690518c056784bc21b4"},
+    {file = "pyasn1_modules-0.2.8-py3.4.egg", hash = "sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811"},
+    {file = "pyasn1_modules-0.2.8-py3.5.egg", hash = "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed"},
+    {file = "pyasn1_modules-0.2.8-py3.6.egg", hash = "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0"},
+    {file = "pyasn1_modules-0.2.8-py3.7.egg", hash = "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd"},
 ]
 
 [package.dependencies]
@@ -2100,4 +2116,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "101a11a15af220d7d95ef724200be5af8efc18e8b25bdeb813dce2f754055742"
+content-hash = "d1d9aa7ad0a91c05ff5e533813ddc592c7686b0aaebaf55f13aeea3795060716"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ lark-parser = "^0.10.0"
 pyyaml = "^5.4.1"
 Sphinx = "^3.5.4"
 markupsafe = "2.0.1"
+mergedeep = "1.3.4"
 
 [tool.poetry.dev-dependencies]
 ipython = "^8.10.0"

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -139,7 +139,8 @@ class TerraformCommand(BaseCommand):
             if plan_file is not None:
                 # if plan file is set, check if it exists, if it does do not plan again
                 if plan_file.exists():
-                    click.secho(f"plan file {plan_file} exists, not planning again")
+                    if self._tf_plan:
+                        click.secho(f"plan file {plan_file} exists, not planning again")
                     execute = True
                     skip_plan = True
 
@@ -291,7 +292,7 @@ class TerraformCommand(BaseCommand):
         if plan_file is not None:
             plan_log = f"{os.path.splitext(plan_file)[0]}.log"
 
-            with open(plan_log, 'w') as pl:
+            with open(plan_log, "w") as pl:
                 pl.write("STDOUT:\n")
                 for line in stdout.decode().splitlines():
                     pl.write(f"{line}\n")

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -21,6 +21,7 @@ from typing import OrderedDict
 import click
 import hcl2
 import jinja2
+from mergedeep import merge
 
 from tfworker import constants as const
 from tfworker.util.copier import CopyFactory
@@ -284,9 +285,11 @@ class DefinitionsCollection(collections.abc.Mapping):
             undefined=jinja2.StrictUndefined,
             loader=jinja2.FileSystemLoader(template_path),
         )
-        jinja_env.globals = self._root_args.template_items(
-            return_as_dict=True, get_env=True
-        ) | { "var": template_vars }
+        jinja_env.globals = merge(
+            {},
+            self._root_args.template_items(return_as_dict=True, get_env=True),
+            {"var": template_vars},
+        )
 
         for template_file in jinja_env.list_templates(filter_func=filter_templates):
             template_target = (

--- a/tfworker/util/system.py
+++ b/tfworker/util/system.py
@@ -17,6 +17,7 @@ import subprocess
 
 import click
 
+
 def pipe_exec(args, stdin=None, cwd=None, env=None, stream_output=False):
     """
     A function to accept a list of commands and pipe them together.


### PR DESCRIPTION
A bug was created in the previous release, where when `template_vars` was supplied for a definition it would overwrite the `var` dictionary that is generated from the --config-var command line inputs. This resolves the issue by using a deep dictionary merge.

Also when --no-plan is specified the worker would still handle the plan file and the output could cause confusion with messages about planfiles when --no-plan would expect to skip all plan related operations.