### PR TITLE
INF-4986: Support configuration blocks in provider configuration

### DIFF
--- a/tfworker/providers/aws.py
+++ b/tfworker/providers/aws.py
@@ -21,4 +21,6 @@ class AWSProvider(BaseProvider):
     def __init__(self, body, authenticators, tf_version_major, **kwargs):
         super(AWSProvider, self).__init__(body, tf_version_major)
         self._authenticator = authenticators.get(self.tag)
+        # need to refresh vars after getting the authenticator as vars
+        # could include authentication information
         self.vars = body.get("vars", {})

--- a/tfworker/providers/base.py
+++ b/tfworker/providers/base.py
@@ -58,7 +58,6 @@ class BaseProvider:
             result.append("  }")
 
         result.append("}")
-        debugstr = "\n".join(result)
         return "\n".join(result)
 
     def required(self):

--- a/tfworker/providers/base.py
+++ b/tfworker/providers/base.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 class BaseProvider:
     tag = None
 
@@ -20,6 +19,7 @@ class BaseProvider:
         self._tf_version_major = tf_version_major
 
         self.vars = body.get("vars", {})
+        self.config_blocks = body.get("config_blocks", {})
         self.version = self.vars.get("version")
         self.source = body.get("source")
 
@@ -28,24 +28,37 @@ class BaseProvider:
     def hcl(self):
         result = []
         provider_vars = {}
+        config_block = {}
+
+        # setup data for provider variables and config blocks
         try:
             for k, v in self.vars.items():
-                if self._tf_version_major >= 13:
-                    if k not in self._field_filter:
-                        provider_vars[k] = v
-                else:
+                if k not in self._field_filter:
                     provider_vars[k] = v
         except (KeyError, TypeError):
             """No provider vars were set."""
             pass
+        for k, v in self.config_blocks.items():
+            config_block[k] = v
 
+        # inject provider block
         result.append(f'provider "{self.tag}" {{')
+
+        # inject provider variables
         for k, v in provider_vars.items():
             if v and '"' not in v:
                 result.append(f'  {k} = "{v}"')
             else:
                 result.append(f"  {k} = {v}")
+
+        # inject provider config blocks
+        for k in self.config_blocks.keys():
+            result.append(f"  {k} {{")
+            result.append(self._hclify(self.config_blocks[k], depth=4))
+            result.append("  }")
+
         result.append("}")
+        debugstr = "\n".join(result)
         return "\n".join(result)
 
     def required(self):
@@ -62,6 +75,38 @@ class BaseProvider:
         """Nothing to do here so far"""
         pass
 
+    def _hclify(self, s, depth=4):
+        """
+        _hcify is a recursive function that takes a string, list or dict
+        and turns the results into an HCL compliant string.
+        """
+        space = ' '
+        result = []
+        if isinstance(s, str):
+            tmps = s.replace('"', "").replace("'", "")
+            result.append(f"{space * depth}{s}")
+        elif isinstance(s, list):
+            tmps = [i.replace('"', "").replace("'", "") for i in s]
+            result.append(f"{space * depth}{s}")
+        elif isinstance(s, dict):
+            # unfortunately, HCL doesn't allow for keys to be quoted so a further
+            # check of the value is required to determine how to handle the key
+            for k in s.keys():
+                if isinstance(s[k], str):
+                    result.append(f"{space * depth}{k} = \"{s[k]}\"")
+                elif isinstance(s[k], list):
+                    result.append(f"{space * depth}{k} = [{s[k]}]")
+                elif isinstance(s[k], dict):
+                    # decrease depth by 4 to account for extra depth added by hclyifying the key
+                    result.append(f"{space * (depth-4)}{self._hclify(k, depth=depth)} = {{")
+                    result.append(self._hclify(s[k], depth=depth + 2))
+                    result.append(f"{space * depth}}}")
+                else:
+                    raise TypeError(f"Expected string, list or dict, got {type(s[k])}")
+        else:
+            raise TypeError(f"Expected string, list or dict, got {type(s)}")
+
+        return "\n".join(result)
 
 class UnknownProvider(Exception):
     def __init__(self, provider):


### PR DESCRIPTION
Some providers leverage HCL configuration blocks for some configuration options, therefore to ensure complete configuration can be accomplished in the worker's configuration file support for more than just variables is required.

A configuration example might look like:
```
  providers:
    aws:
      requirements:
        version: 4.61.0
      vars:
        region: us-east-1
      config_blocks:
        default_tags: {
          tags: {
            "Terraform": "true",
            "Environment": "staging",
            "Owner": "Infrastructure",
          }
        }
```