### PR TITLE
INF-5078: support sub_path on the file system copier

### DIFF
--- a/tests/commands/test_root.py
+++ b/tests/commands/test_root.py
@@ -14,6 +14,7 @@
 
 import copy
 import os
+import platform
 from tempfile import TemporaryDirectory
 from unittest import mock
 
@@ -49,7 +50,10 @@ class TestMain:
         # if working_dir is passed, clean should be false
         rc = tfworker.commands.root.RootCommand(args={"working_dir": "/tmp"})
         assert rc.clean is False
-        assert str(rc.temp_dir) == "/tmp"
+        if platform.system() == "Darwin":
+            assert str(rc.temp_dir) == "/private/tmp"
+        else:
+            assert str(rc.temp_dir) == "/tmp"
 
         # if clean is passed, it should be set to the value passed
         rc = tfworker.commands.root.RootCommand(args={"clean": False})
@@ -64,7 +68,10 @@ class TestMain:
             args={"clean": True, "working_dir": tmpdir.name}
         )
         assert rc.clean is True
-        assert str(rc.temp_dir) == tmpdir.name
+        if platform.system() == "Darwin":
+            assert str(rc.temp_dir) == f"/private{tmpdir.name}"
+        else:
+            assert str(rc.temp_dir) == tmpdir.name
         with open(file=os.path.join(tmpdir.name, "test"), mode="w") as f:
             f.write("test")
         del rc

--- a/tfworker/util/copier.py
+++ b/tfworker/util/copier.py
@@ -230,7 +230,8 @@ class FileSystemCopier(Copier):
         """copy copies files from a local source on the file system to a destination path"""
         dest = self.get_destination(**kwargs)
         self.check_conflicts(self.local_path)
-        shutil.copytree(self.local_path, dest, dirs_exist_ok=True)
+        source_path = f"{self.local_path}/{kwargs.get('sub_path', '')}".rstrip("/")
+        shutil.copytree(source_path, dest, dirs_exist_ok=True)
 
     @property
     def local_path(self):


### PR DESCRIPTION
This adds support for honoring the "sub_path" option when using the file system copier.

This also adds more thorough tests for the FileSystemCopier.local_path method

This also corrects tests that are failing on OSX due to how /tmp is handled