### PR TITLE
Handle Git Copier Error

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -207,13 +207,13 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2023.5.7"
+version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
-    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
+    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
+    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
 ]
 
 [[package]]

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -136,6 +136,12 @@ class Definition:
                 raise e
         except FileExistsError as e:
             raise ReservedFileError(e)
+        except RuntimeError as e:
+            click.secho(
+                f"could not copy source path {self.path} for definition {self.tag}, error details:\n\n{e}",
+                fg="red",
+            )
+            raise SystemExit(1)
 
         # render the templates
         if self._template_callback is not None:

--- a/tfworker/util/copier.py
+++ b/tfworker/util/copier.py
@@ -158,7 +158,7 @@ class GitCopier(Copier):
 
         self.make_temp()
         temp_path = f"{self._temp_dir}/{sub_path}"
-        pipe_exec(
+        exitcode, stdout, stderr = pipe_exec(
             re.sub(
                 r"\s+",
                 " ",
@@ -166,6 +166,10 @@ class GitCopier(Copier):
             ),
             cwd=self._temp_dir,
         )
+
+        if exitcode != 0:
+            self.clean_temp()
+            raise RuntimeError(f"unable to clone {self._source}, {stderr.decode('utf-8')}")
 
         try:
             self.check_conflicts(temp_path)


### PR DESCRIPTION
When specifying an invalid remote branch, a `plan` operation may be quite alarming as it will show all resources to be removed since the git clone operation silently failed.

This checks the result of the git operation, and handles the error in a friendly way.

This PR also includes an update to `certifi` which triggers a dependabot alert though it's not associated with a CVE. More details about the reasoning for this issue appear in this mozilla writeup: https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/C-HrP1SEq1A
