### PR TITLE
use s3 bucket to prepopulate all possible remote states

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,7 @@ def grootc():
             "backend_region": "us-central1",
             "backend_bucket": "test_gcp_bucket",
             "backend_prefix": "terraform/test-0002",
+            "backend_use_all_remotes": False,
             "config_file": os.path.join(
                 os.path.dirname(__file__), "fixtures", "gcp_test_config.yaml"
             ),
@@ -132,6 +133,7 @@ def grootc_no_create_backend_bucket():
             "backend_region": "us-central1",
             "backend_bucket": "test_gcp_bucket",
             "backend_prefix": "terraform/test-0002",
+            "backend_use_all_remotes": False,
             "config_file": os.path.join(
                 os.path.dirname(__file__), "fixtures", "gcp_test_config.yaml"
             ),
@@ -157,6 +159,7 @@ def rootc(s3_client, dynamodb_client, sts_client, create_backend_bucket=True):
             "backend_region": "us-west-2",
             "backend_bucket": "test_bucket",
             "backend_prefix": "terraform/test-0001",
+            "backend_use_all_remotes": False,
             "config_file": os.path.join(
                 os.path.dirname(__file__), "fixtures", "test_config.yaml"
             ),
@@ -182,6 +185,7 @@ def rootc_no_create_backend_bucket(s3_client, dynamodb_client, sts_client):
             "backend_region": "us-west-2",
             "backend_bucket": "test_bucket",
             "backend_prefix": "terraform/test-0001",
+            "backend_use_all_remotes": False,
             "config_file": os.path.join(
                 os.path.dirname(__file__), "fixtures", "test_config.yaml"
             ),
@@ -207,6 +211,7 @@ def json_base_rootc(s3_client, dynamodb_client, sts_client):
             "backend_region": "us-west-2",
             "backend_bucket": "test_bucket",
             "backend_prefix": "terraform/test-0001",
+            "backend_use_all_remotes": False,
             "config_file": os.path.join(
                 os.path.dirname(__file__), "fixtures", "base_config_test.json"
             ),
@@ -231,6 +236,7 @@ def yaml_base_rootc(s3_client, dynamodb_client, sts_client):
             "backend_region": "us-west-2",
             "backend_bucket": "test_bucket",
             "backend_prefix": "terraform/test-0001",
+            "backend_use_all_remotes": False,
             "config_file": os.path.join(
                 os.path.dirname(__file__), "fixtures", "base_config_test.yaml"
             ),
@@ -255,6 +261,7 @@ def hcl_base_rootc(s3_client, dynamodb_client, sts_client):
             "backend_region": "us-west-2",
             "backend_bucket": "test_bucket",
             "backend_prefix": "terraform/test-0001",
+            "backend_use_all_remotes": False,
             "config_file": os.path.join(
                 os.path.dirname(__file__), "fixtures", "base_config_test.hcl"
             ),
@@ -284,6 +291,7 @@ def rootc_options(s3_client, dynamodb_client, sts_client):
             "backend_region": "us-west-2",
             "backend_bucket": "test_bucket",
             "backend_prefix": "terraform/test-0001",
+            "backend_use_all_remotes": False,
             "config_file": os.path.join(
                 os.path.dirname(__file__), "fixtures", "test_config_with_options.yaml"
             ),

--- a/tfworker/backends/base.py
+++ b/tfworker/backends/base.py
@@ -36,6 +36,10 @@ class BaseBackend(metaclass=ABCMeta):
     def clean(self, deployment: str, limit: tuple) -> str:
         pass
 
+    @abstractmethod
+    def remotes(self) -> list:
+        pass
+
 
 class Backends:
     s3 = "s3"

--- a/tfworker/backends/gcs.py
+++ b/tfworker/backends/gcs.py
@@ -95,6 +95,10 @@ class GCSBackend(BaseBackend):
             else:
                 raise BackendError(f"state file at: {b.name} is not empty")
 
+    def remotes(self) -> list:
+        """ this is unimplemented here """
+        raise NotImplementedError
+
     def _get_state_list(self) -> list:
         """
         _get_state_list returns a list of states inside of the prefix, since this is looking for state/folders only

--- a/tfworker/backends/s3.py
+++ b/tfworker/backends/s3.py
@@ -112,6 +112,26 @@ class S3Backend(BaseBackend):
                     "Backend bucket not found and --no-create-backend-bucket specified."
                 )
 
+        # Generate a list of all files in the bucket, at the desired prefix for the deployment
+        s3_paginator = self._s3_client.get_paginator("list_objects_v2").paginate(
+            Bucket=self._authenticator.bucket,
+            Prefix=self._authenticator.prefix,
+        )
+
+        self._bucket_files = set()
+        for page in s3_paginator:
+            if "Contents" in page:
+                for key in page["Contents"]:
+                    # just append the last part of the prefix to the list
+                    self._bucket_files.add(key["Key"].split("/")[-2])
+
+        # print (self._authenticator.bucket)
+        # print (self._authenticator.prefix)
+
+    def remotes(self) -> list:
+        """ return a list of the remote bucket keys """
+        return list(self._bucket_files)
+
     def _check_table_exists(self, name: str) -> bool:
         """check if a supplied dynamodb table exists"""
         if name in self._ddb_client.list_tables()["TableNames"]:

--- a/tfworker/backends/s3.py
+++ b/tfworker/backends/s3.py
@@ -125,9 +125,6 @@ class S3Backend(BaseBackend):
                     # just append the last part of the prefix to the list
                     self._bucket_files.add(key["Key"].split("/")[-2])
 
-        # print (self._authenticator.bucket)
-        # print (self._authenticator.prefix)
-
     def remotes(self) -> list:
         """ return a list of the remote bucket keys """
         return list(self._bucket_files)

--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -181,6 +181,12 @@ def validate_working_dir(fpath):
     help="Region where terraform rootc/lock bucket exists",
 )
 @click.option(
+    "--backend-use-all-remotes/--no-backend-use-all-remotes",
+    default=False,
+    envvar="WORKER_BACKEND_USE_ALL_REMOTES",
+    help="Generate remote data sources based on all definition paths present in the backend",
+)
+@click.option(
     "--create-backend-bucket/--no-create-backend-bucket",
     default=True,
     help="Create the backend bucket if it does not exist",
@@ -330,7 +336,13 @@ def version():
 @click.pass_obj
 def terraform(rootc, *args, **kwargs):
     """execute terraform orchestration"""
-    tfc = TerraformCommand(rootc, *args, **kwargs)
+    try:
+        tfc = TerraformCommand(rootc, *args, **kwargs)
+    except FileNotFoundError as e:
+        click.secho(
+            f"terraform binary not found: {e.filename}", fg="red", err=True
+        )
+        raise SystemExit(1)
 
     click.secho(f"building deployment {kwargs.get('deployment')}", fg="green")
     click.secho(f"working in directory: {tfc.temp_dir}", fg="yellow")


### PR DESCRIPTION
Handle a few error conditions:
- plugin not available to download (happens when a deprecated plugin not built for arm!)
- unhandled exception when user specified terraform binary didn't exist

Add option:
    "--backend-use-all-remotes/--no-backend-use-all-remotes"
    envvar="WORKER_BACKEND_USE_ALL_REMOTES"
    default=False

This option causes all possible definitions in the bucket prefix for the deployment to be setup as a remote data source. They can then be referenced as a remote_var without having to include the definition in the same configuration