### PR TITLE
make `not planning again` noticable

### DIFF
--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -143,7 +143,7 @@ class TerraformCommand(BaseCommand):
                 # if plan file is set, check if it exists, if it does do not plan again
                 if plan_file.exists():
                     if self._tf_plan:
-                        click.secho(f"plan file {plan_file} exists, not planning again")
+                        click.secho(f"plan file {plan_file} exists, not planning again", fg="red")
                     execute = True
                     skip_plan = True
 


### PR DESCRIPTION
When the terraform worker declines to plan again due to an existing plan, output the text in red so it's not lost amidst the flood of green and white text.