### PR TITLE
Add support for stashing plans in the backend

### DIFF
--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -230,7 +230,7 @@ class TestTerraformCommand:
     #                 )
 
     def test_no_create_backend_bucket_fails_gcs(self, grootc_no_create_backend_bucket):
-        with pytest.raises(BackendError):
+        with pytest.raises(SystemExit):
             with mock.patch(
                 "tfworker.commands.base.BaseCommand.get_terraform_version",
                 side_effect=lambda x: (13, 3),

--- a/tests/util/test_copier.py
+++ b/tests/util/test_copier.py
@@ -33,6 +33,7 @@ if platform.system() == "Darwin":
 else:
     C_ROOT_PATH = "/tmp/test/"
 
+
 @pytest.fixture(scope="session")
 def register_test_copier():
     @CopyFactory.register("testfixture")
@@ -342,7 +343,9 @@ class TestFileSystemCopier:
 
         # Ensure file not found error is raised on invalid relative path
         with pytest.raises(FileNotFoundError):
-            FileSystemCopier(source="some/invalid/path", root_path=os.getcwd()).local_path
+            FileSystemCopier(
+                source="some/invalid/path", root_path=os.getcwd()
+            ).local_path
 
         # Ensure file not found error is raised on invalid absolute path
         with pytest.raises(FileNotFoundError):
@@ -357,10 +360,7 @@ class TestFileSystemCopier:
         # this should return true because the source is a valid directory
         assert FileSystemCopier.type_match(source) is True
         # this should return false because the full path to source does not exist inside of root_path
-        assert (
-            FileSystemCopier.type_match("/some/invalid/path")
-            is False
-        )
+        assert FileSystemCopier.type_match("/some/invalid/path") is False
         # this should return true because the full path to source exists inside of root_path
         assert (
             FileSystemCopier.type_match(

--- a/tfworker/backends/__init__.py
+++ b/tfworker/backends/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import Backends
+from .base import BackendError, Backends, BaseBackend  # noqa
 from .gcs import GCSBackend  # noqa
 from .s3 import S3Backend  # noqa
 

--- a/tfworker/backends/base.py
+++ b/tfworker/backends/base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod, abstractproperty
 
 from tfworker import JSONType
 
@@ -22,6 +22,7 @@ class BackendError(Exception):
 
 
 class BaseBackend(metaclass=ABCMeta):
+    plan_storage = False
     tag = "base"
 
     @abstractmethod
@@ -39,6 +40,10 @@ class BaseBackend(metaclass=ABCMeta):
     @abstractmethod
     def remotes(self) -> list:
         pass
+
+    @property
+    def handlers(self) -> dict:
+        return {}
 
 
 class Backends:

--- a/tfworker/backends/s3.py
+++ b/tfworker/backends/s3.py
@@ -16,22 +16,28 @@ import json
 import os
 import sys
 from contextlib import closing
+from pathlib import Path
+from uuid import uuid4
 
 import boto3
 import botocore
 import click
 
+from ..handlers import BaseHandler, HandlerError
 from .base import BackendError, BaseBackend, validate_backend_empty
 
 
 class S3Backend(BaseBackend):
     tag = "s3"
     auth_tag = "aws"
+    plan_storage = False
 
     def __init__(self, authenticators, definitions, deployment=None):
         self._authenticator = authenticators[self.auth_tag]
         self._definitions = definitions
         self._deployment = "undefined"
+        self._handlers = None
+
         if deployment:
             self._deployment = deployment
 
@@ -112,7 +118,7 @@ class S3Backend(BaseBackend):
                     "Backend bucket not found and --no-create-backend-bucket specified."
                 )
 
-        # Generate a list of all files in the bucket, at the desired prefix for the deployment
+        # Generate a list of all files in the bucket, at the desired prefix for the deployment, used for "--all-remote-states" option and clean
         s3_paginator = self._s3_client.get_paginator("list_objects_v2").paginate(
             Bucket=self._authenticator.bucket,
             Prefix=self._authenticator.prefix,
@@ -124,9 +130,22 @@ class S3Backend(BaseBackend):
                 for key in page["Contents"]:
                     # just append the last part of the prefix to the list
                     self._bucket_files.add(key["Key"].split("/")[-2])
+        try:
+            self._handlers = S3Handler(self._authenticator)
+            self.plan_storage = True
+        except HandlerError as e:
+            click.secho(f"Error initializing S3Handler: {e}")
+            raise SystemExit(1)
+
+    @property
+    def handlers(self) -> dict:
+        """
+        handlers returns a dictionary of handlers for the backend, ensure a singleton
+        """
+        return {self.tag: self._handlers}
 
     def remotes(self) -> list:
-        """ return a list of the remote bucket keys """
+        """return a list of the remote bucket keys"""
         return list(self._bucket_files)
 
     def _check_table_exists(self, name: str) -> bool:
@@ -302,3 +321,171 @@ class S3Backend(BaseBackend):
                     yield content["Key"]
         except TypeError:
             pass
+
+
+class S3Handler(BaseHandler):
+    """The S3Handler class is a handler for the s3 backend"""
+
+    actions = ["plan", "apply"]
+    required_vars = []
+    _is_ready = False
+
+    def __init__(self, authenticator):
+        try:
+            self.execution_functions = {
+                "plan": {
+                    "check": self._check_plan,
+                    "post": self._post_plan,
+                },
+                "apply": {
+                    "pre": self._pre_apply,
+                },
+            }
+
+            self._authenticator = authenticator
+            self._s3_client = self._authenticator.backend_session.client("s3")
+
+        except Exception as e:
+            raise HandlerError(f"Error initializing S3Handler: {e}")
+
+    def is_ready(self):
+        if not self._is_ready:
+            filename = str(uuid4().hex[:6].upper())
+            if self._s3_client.list_objects(
+                Bucket=self._authenticator.bucket,
+                Prefix=f"{self._authenticator.prefix}/{filename}",
+            ).get("Contents"):
+                raise HandlerError(
+                    f"Error initializing S3Handler, remote file already exists: {filename}"
+                )
+            try:
+                self._s3_client.upload_file(
+                    "/dev/null",
+                    self._authenticator.bucket,
+                    f"{self._authenticator.prefix}/{filename}",
+                )
+            except boto3.exceptions.S3UploadFailedError as e:
+                raise HandlerError(
+                    f"Error initializing S3Handler, could not create file: {e}"
+                )
+            try:
+                self._s3_client.delete_object(
+                    Bucket=self._authenticator.bucket,
+                    Key=f"{self._authenticator.prefix}/{filename}",
+                )
+            except boto3.exceptions.S3UploadFailedError as e:
+                raise HandlerError(
+                    f"Error initializing S3Handler, could not delete file: {e}"
+                )
+            self._is_ready = True
+        return self._is_ready
+
+    def execute(self, action, stage, **kwargs):
+        # save a copy of the planfile to the backend state bucket
+        if action in self.execution_functions.keys():
+            if stage in self.execution_functions[action].keys():
+                self.execution_functions[action][stage](**kwargs)
+        return None
+
+    def _check_plan(self, planfile: Path, definition: str, **kwargs):
+        """check_plan runs while the plan is being checked, it should fetch a file from the backend and store it in the local location"""
+        # ensure planfile does not exist or is zero bytes if it does
+        remotefile = f"{self._authenticator.prefix}/{definition}/{planfile.name}"
+        if planfile.exists():
+            if planfile.stat().st_size == 0:
+                planfile.unlink()
+            else:
+                raise HandlerError(f"planfile already exists: {planfile}")
+
+        if self._s3_get_plan(planfile, remotefile):
+            if not planfile.exists():
+                raise HandlerError(f"planfile not found after download: {planfile}")
+            click.secho(
+                f"remote planfile downloaded: s3://{self._authenticator.bucket}/{remotefile} -> {planfile}",
+                fg="yellow",
+            )
+
+    def _post_plan(
+        self, planfile: Path, definition: str, changes: bool = False, **kwargs
+    ):
+        """post_apply runs after the apply is complete, it should upload the planfile to the backend"""
+        logfile = planfile.with_suffix(".log")
+        remotefile = f"{self._authenticator.prefix}/{definition}/{planfile.name}"
+        remotelog = remotefile.replace(".tfplan", ".log")
+        if "text" in kwargs.keys():
+            with open(logfile, "w") as f:
+                f.write(kwargs["text"])
+        if planfile.exists() and changes:
+            if self._s3_put_plan(planfile, remotefile):
+                click.secho(
+                    f"remote planfile uploaded: {planfile} -> s3://{self._authenticator.bucket}/{remotefile}",
+                    fg="yellow",
+                )
+                if self._s3_put_plan(logfile, remotelog):
+                    click.secho(
+                        f"remote logfile uploaded: {logfile} -> s3://{self._authenticator.bucket}/{remotelog}",
+                        fg="yellow",
+                    )
+        return None
+
+    def _pre_apply(self, planfile: Path, definition: str, **kwargs):
+        """_pre_apply runs before the apply is started, it should remove the planfile from the backend"""
+        logfile = planfile.with_suffix(".log")
+        remotefile = f"{self._authenticator.prefix}/{definition}/{planfile.name}"
+        remotelog = remotefile.replace(".tfplan", ".log")
+        if self._s3_delete_plan(remotefile, planfile):
+            click.secho(
+                f"remote planfile removed: s3://{self._authenticator.bucket}/{remotefile}",
+                fg="yellow",
+            )
+        if self._s3_delete_plan(remotelog, logfile):
+            click.secho(
+                f"remote logfile removed: s3://{self._authenticator.bucket}/{remotelog}",
+                fg="yellow",
+            )
+        return None
+
+    def _s3_get_plan(self, planfile: Path, remotefile: str) -> bool:
+        """_get_plan downloads the file from s3"""
+        # fetch the planfile from the backend
+        downloaded = False
+        try:
+            self._s3_client.download_file(
+                self._authenticator.bucket, remotefile, planfile
+            )
+            # make sure the local file exists, and is greater than 0 bytes
+            downloaded = True
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == "404":
+                click.secho(f"remote plan {remotefile} not found", fg="yellow")
+                pass
+            else:
+                raise HandlerError(f"Error downloading planfile: {e}")
+        return downloaded
+
+    def _s3_put_plan(self, planfile: Path, remotefile: str) -> bool:
+        """_put_plan uploads the file to s3"""
+        uploaded = False
+        # don't upload empty plans
+        if planfile.stat().st_size == 0:
+            return uploaded
+        try:
+            self._s3_client.upload_file(
+                str(planfile), self._authenticator.bucket, remotefile
+            )
+            uploaded = True
+        except botocore.exceptions.ClientError as e:
+            raise HandlerError(f"Error uploading planfile: {e}")
+        return uploaded
+
+    def _s3_delete_plan(self, remotefile: str, planfile: str) -> bool:
+        """_delete_plan removes a remote plan file"""
+        deleted = False
+        try:
+            self._s3_client.delete_object(
+                Bucket=self._authenticator.bucket, Key=remotefile
+            )
+            deleted = True
+        except botocore.exceptions.ClientError as e:
+            raise HandlerError(f"Error deleting planfile: {e}")
+        return deleted

--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -209,6 +209,12 @@ def validate_working_dir(fpath):
     envvar="WORKER_CLEAN",
     help="clean up the temporary directory created by the worker after execution",
 )
+@click.option(
+    "--backend-plans/--no-backend-plans",
+    default=False,
+    envvar="WORKER_BACKEND_PLANS",
+    help="store plans in the backend",
+)
 @click.pass_context
 def cli(context, **kwargs):
     """CLI for the worker utility."""
@@ -262,6 +268,7 @@ def version():
     "--plan/--no-plan",
     "tf_plan",
     envvar="WORKER_PLAN",
+    type=bool,
     default=True,
     help="toggle running a plan, plan will still be skipped if using a saved plan file with apply",
 )
@@ -339,9 +346,7 @@ def terraform(rootc, *args, **kwargs):
     try:
         tfc = TerraformCommand(rootc, *args, **kwargs)
     except FileNotFoundError as e:
-        click.secho(
-            f"terraform binary not found: {e.filename}", fg="red", err=True
-        )
+        click.secho(f"terraform binary not found: {e.filename}", fg="red", err=True)
         raise SystemExit(1)
 
     click.secho(f"building deployment {kwargs.get('deployment')}", fg="green")

--- a/tfworker/handlers/__init__.py
+++ b/tfworker/handlers/__init__.py
@@ -1,5 +1,6 @@
 import collections
 
+from .base import BaseHandler
 from .bitbucket import BitbucketHandler
 from .exceptions import HandlerError, UnknownHandler
 
@@ -33,6 +34,18 @@ class HandlersCollection(collections.abc.Mapping):
 
     def __iter__(self):
         return iter(self._handlers.values())
+
+    def __setitem__(self, key, value):
+        self._handlers[key] = value
+
+    def update(self, handlers_config):
+        """
+        update is used to update the handlers collection with new handlers
+        """
+        for k in handlers_config:
+            if k in self._handlers.keys():
+                raise TypeError(f"Duplicate handler: {k}")
+            self._handlers[k] = handlers_config[k]
 
     def get(self, value):
         try:

--- a/tfworker/handlers/base.py
+++ b/tfworker/handlers/base.py
@@ -9,10 +9,17 @@ class BaseHandler(metaclass=ABCMeta):
 
     @abstractmethod
     def is_ready(self):  # pragma: no cover
+        """is_ready is called to determine if a handler is ready to be executed"""
         return True
 
     @abstractmethod
-    def execute(self, action, **kwargs):  # pragma: no cover
+    def execute(self, action: str, stage: str, **kwargs) -> None:  # pragma: no cover
+        """
+        execute is called when a handler should trigger, it accepts to parameters
+            action: the action that triggered the handler (one of plan, clean, apply, destroy)
+            stage: the stage of the action (one of pre, post)
+            kwargs: any additional arguments that may be required
+        """
         pass
 
 

--- a/tfworker/handlers/bitbucket.py
+++ b/tfworker/handlers/bitbucket.py
@@ -71,7 +71,7 @@ class BitbucketHandler(BaseHandler):
         """
         return self._ready
 
-    def execute(self, action, **kwargs):
+    def execute(self, action, stage, **kwargs):
         """
         execute is a generic method that will execute the specified action with the provided arguments.
         """

--- a/tfworker/plugins.py
+++ b/tfworker/plugins.py
@@ -21,9 +21,11 @@ import urllib
 import zipfile
 
 import click
-from tenacity import retry, stop_after_attempt, wait_chain, wait_fixed, RetryError, retry_if_not_exception_message
+from tenacity import (RetryError, retry, retry_if_not_exception_message,
+                      stop_after_attempt, wait_chain, wait_fixed)
 
 from tfworker.commands.root import get_platform
+
 
 class PluginSourceParseException(Exception):
     pass
@@ -100,6 +102,7 @@ class PluginsCollection(collections.abc.Mapping):
                 except PluginSourceParseException as e:
                     click.secho(str(e), fg="red")
                     click.Abort()
+
 
 class PluginSource:
     """

--- a/tfworker/providers/base.py
+++ b/tfworker/providers/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class BaseProvider:
     tag = None
 
@@ -79,7 +80,7 @@ class BaseProvider:
         _hcify is a recursive function that takes a string, list or dict
         and turns the results into an HCL compliant string.
         """
-        space = ' '
+        space = " "
         result = []
         if isinstance(s, str):
             tmps = s.replace('"', "").replace("'", "")
@@ -92,12 +93,14 @@ class BaseProvider:
             # check of the value is required to determine how to handle the key
             for k in s.keys():
                 if isinstance(s[k], str):
-                    result.append(f"{space * depth}{k} = \"{s[k]}\"")
+                    result.append(f'{space * depth}{k} = "{s[k]}"')
                 elif isinstance(s[k], list):
                     result.append(f"{space * depth}{k} = [{s[k]}]")
                 elif isinstance(s[k], dict):
                     # decrease depth by 4 to account for extra depth added by hclyifying the key
-                    result.append(f"{space * (depth-4)}{self._hclify(k, depth=depth)} = {{")
+                    result.append(
+                        f"{space * (depth-4)}{self._hclify(k, depth=depth)} = {{"
+                    )
                     result.append(self._hclify(s[k], depth=depth + 2))
                     result.append(f"{space * depth}}}")
                 else:
@@ -106,6 +109,7 @@ class BaseProvider:
             raise TypeError(f"Expected string, list or dict, got {type(s)}")
 
         return "\n".join(result)
+
 
 class UnknownProvider(Exception):
     def __init__(self, provider):

--- a/tfworker/util/copier.py
+++ b/tfworker/util/copier.py
@@ -169,7 +169,9 @@ class GitCopier(Copier):
 
         if exitcode != 0:
             self.clean_temp()
-            raise RuntimeError(f"unable to clone {self._source}, {stderr.decode('utf-8')}")
+            raise RuntimeError(
+                f"unable to clone {self._source}, {stderr.decode('utf-8')}"
+            )
 
         try:
             self.check_conflicts(temp_path)


### PR DESCRIPTION
This PR intoduces a significant amount of change, to summarize:
* added proper handling for GCS backend errors
* add CLI flag --backend-plans to trigger storing plans in the selected backend
* add plan_storage flag to backends to indicate if they support remote plan storage
* add ability for backends to have handlers
* add handler for the S3 backend to store and retrieve plans
* refactor the TerraformCommand.exec into smaller units, the function was a mess of conditions
* update Definition to store the plan_file since it's broadly needed and a 1:1 relationship
* implement `update` on the HandlersCollection to make it more dict like
* apply black formatting