### PR TITLE
INF-5144: validate planfile lineage

### DIFF
--- a/tfworker/commands/base.py
+++ b/tfworker/commands/base.py
@@ -135,7 +135,7 @@ class BaseCommand:
             raise SystemExit(1)
 
         # allow a backend to implement handlers as well since they already control the provider session
-        if self._backend.handlers:
+        if self._backend.handlers and self._backend_plans:
             self._handlers.update(self._backend.handlers)
 
     @property

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -283,9 +283,6 @@ class TerraformCommand(BaseCommand):
     def _exec_apply_or_destroy(self, definition) -> None:
         """_exec_apply_or_destroy executes a terraform apply or destroy"""
         # call handlers for pre apply
-        click.secho(
-            f"DEBUG: executing {self._plan_for} for {definition.tag}", fg="yellow"
-        )
         try:
             self._execute_handlers(
                 action=self._plan_for,


### PR DESCRIPTION
This PR ensures that a provided backend plan matches the current terraform state. This is an important check to make sure that the plan file being consumed is appropriate for the terraform state.

In addition the following minor changes are also included:
* only load backend handlers when --backend-plans is provided
* remove extraneous DEBUG message