### PR TITLE
INF-5500: add trivy handler

### DIFF
--- a/tests/fixtures/terraform-modules/test_a/test.tf
+++ b/tests/fixtures/terraform-modules/test_a/test.tf
@@ -1,12 +1,8 @@
 # this file is a test fixture, it's used to test module copy functions
-coup3xaiW0rooHaicieg
-FauGha4tu1aed2bai1foo
-Ohbee6jeine5piejo2kaik
-aiGh1jaek5eu1quaih6Ceef
-Ohc7yeengooshaiThiBuRoh4
-ohkeeci3ahChoongohnix5iew
-aiVae0nohshae3eukeephiesh9
-taix6haishahhohd2ahPheeth3I
-zoozeipeZ6phie7ohj0ye5weepah
-Wone6thooVith8tukiepah9ohp2Ei
-wohte0Eigohseelieg7Po1eib2igh8
+locals {
+    test = [
+        "coup3xaiW0rooHaicieg",
+        "FauGha4tu1aed2bai1foo",
+        "Ohbee6jeine5piejo2kaik",
+    ]
+}

--- a/tests/fixtures/terraform-modules/test_b/test.tf
+++ b/tests/fixtures/terraform-modules/test_b/test.tf
@@ -1,12 +1,8 @@
 # this file is a test fixture, it's used to test module copy functions
-phai1Eekei9adieNgahm
-een3ahh2Evuu5oX4ahvay
-Lei2vaekaeyohxah7iyo8e
-Heech7eez3aiciequ2shaix
-Ohj0BiveQuei0aiFi8aechoo
-Am2ahpaenaiGai0aLaiw5shah
-pee9eew5dah5Dee9igheetheen
-phef9aiG3ahw1rohzi0ailoo5Ea
-su6Ju1aewae1Eew7ziwi5ahbahf9
-aengu7Oshaeshiceehee6iup0eevi
-wae9toh7Coothei2WuazagahPaphai
+locals {
+    test = [
+        "phai1Eekei9adieNgahm",
+        "een3ahh2Evuu5oX4ahvay",
+        "Lei2vaekaeyohxah7iyo8e"
+    ]
+}

--- a/tests/handlers/test_exceptions.py
+++ b/tests/handlers/test_exceptions.py
@@ -1,0 +1,34 @@
+import pytest
+
+from tfworker.handlers.exceptions import HandlerError, UnknownHandler
+
+
+def test_handler_error():
+    error_message = "This is a test error message"
+    terminate = True
+
+    error = HandlerError(error_message, terminate)
+
+    assert error.message == error_message
+    assert error.terminate == terminate
+    assert str(error) == f"Handler error: {error_message}"
+
+
+def test_handler_error_no_terminate():
+    error_message = "This is a test error message"
+    terminate = False
+
+    error = HandlerError(error_message, terminate)
+
+    assert error.message == error_message
+    assert error.terminate == terminate
+    assert str(error) == f"Handler error: {error_message}"
+
+
+def test_unknown_handler():
+    provider = "aws"
+
+    error = UnknownHandler(provider)
+
+    assert error.provider == provider
+    assert str(error) == f"Unknown handler: {provider}"

--- a/tests/handlers/test_trivy.py
+++ b/tests/handlers/test_trivy.py
@@ -1,0 +1,311 @@
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from tfworker.handlers.exceptions import HandlerError
+from tfworker.handlers.trivy import TrivyHandler
+
+
+class TestTrivyHandlerTrivyRunnable(unittest.TestCase):
+    def test_trivy_not_runnable(self):
+        with self.assertRaises(HandlerError):
+            TrivyHandler({"path": "/path/to/trivy"})
+
+    @patch("os.path.exists")
+    @patch("os.access")
+    def test_trivy_runnable(self, mock_access, mock_exists):
+        mock_exists.return_value = True
+        mock_access.return_value = True
+        self.assertTrue(TrivyHandler._trivy_runable("/path/to/trivy"))
+
+    @patch("os.path.exists")
+    def test_trivy_not_runnable_no_exists(self, mock_exists):
+        mock_exists.return_value = False
+        self.assertFalse(TrivyHandler._trivy_runable("/path/to/trivy"))
+
+    @patch("os.path.exists")
+    @patch("os.access")
+    def test_trivy_not_runnable_no_access(self, mock_access, mock_exists):
+        mock_exists.return_value = True
+        mock_access.return_value = False
+        self.assertFalse(TrivyHandler._trivy_runable("/path/to/trivy"))
+
+
+class TestTrivyHandlerExecute(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def trivy_runnable_patcher(self):
+        patcher = patch("tfworker.handlers.trivy.TrivyHandler._trivy_runable")
+        mock_trivy_runable = patcher.start()
+        mock_trivy_runable.return_value = True
+        yield mock_trivy_runable
+
+    def test__raise_if_not_ready(self):
+        handler = TrivyHandler({})
+        handler._ready = False
+        with self.assertRaises(HandlerError):
+            handler.execute("plan", "pre")
+
+    def test_execute_pre_plan_without_definition_path(self):
+        handler = TrivyHandler({})
+        with self.assertRaises(HandlerError):
+            handler.execute("plan", "pre")
+
+    @patch("tfworker.handlers.trivy.click")
+    def test_execute_pre_plan_skip_definition(self, mock_click):
+        handler = TrivyHandler({"skip_definition": True})
+        handler._trivy_runable = MagicMock(return_value=True)
+        handler.is_ready = MagicMock(return_value=True)
+        handler.execute("plan", "pre", definition_path="/path/to/definition")
+        mock_click.secho.assert_called_with(
+            "Skipping trivy scan of definition", fg="yellow"
+        )
+
+    @patch("tfworker.handlers.trivy.click")
+    def test_execute_pre_plan_scan_definition(self, mock_click):
+        handler = TrivyHandler({})
+        handler.is_ready = MagicMock(return_value=True)
+        handler._scan = MagicMock()
+        handler.execute("plan", "pre", definition_path="/path/to/definition")
+        mock_click.secho.assert_called_with(
+            "scanning definition with trivy: /path/to/definition", fg="green"
+        )
+        handler._scan.assert_called_with("/path/to/definition")
+
+    def test_execute_post_plan_without_planfile(self):
+        handler = TrivyHandler({})
+        with self.assertRaises(HandlerError):
+            handler.execute("plan", "post", changes=True)
+
+    def test_execute_post_plan_without_definition_path(self):
+        handler = TrivyHandler({})
+        with self.assertRaises(HandlerError):
+            handler.execute("plan", "post", planfile="/path/to/planfile", changes=True)
+
+    @patch("tfworker.handlers.trivy.click")
+    def test_execute_post_plan_skip_planfile(self, mock_click):
+        handler = TrivyHandler({"skip_planfile": True})
+        handler.is_ready = MagicMock(return_value=True)
+        handler.execute(
+            "plan",
+            "post",
+            planfile="/path/to/planfile",
+            definition_path="/path/to/definition",
+            changes=True,
+        )
+        mock_click.secho.assert_called_with(
+            "Skipping trivy scan of planfile", fg="yellow"
+        )
+
+    @patch("tfworker.handlers.trivy.click")
+    def test_execute_post_plan_scan_planfile(self, mock_click):
+        handler = TrivyHandler({})
+        handler.is_ready = MagicMock(return_value=True)
+        handler._scan = MagicMock()
+        handler.execute(
+            "plan",
+            "post",
+            planfile="/path/to/planfile",
+            definition_path="/path/to/definition",
+            changes=True,
+        )
+        mock_click.secho.assert_called_with(
+            "scanning planfile with trivy: /path/to/planfile", fg="green"
+        )
+        handler._scan.assert_called_with("/path/to/definition", "/path/to/planfile")
+
+
+class TestTrivyHandlerScan(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def trivy_runnable_patcher(self):
+        patcher = patch("tfworker.handlers.trivy.TrivyHandler._trivy_runable")
+        mock_trivy_runable = patcher.start()
+        mock_trivy_runable.return_value = True
+        yield mock_trivy_runable
+
+    @patch("tfworker.handlers.trivy.pipe_exec")
+    @patch("tfworker.handlers.trivy.click")
+    def test__scan_definition_success_with_defaults(self, mock_click, mock_pipe_exec):
+        mock_pipe_exec.return_value = (0, "stdout", "stderr")
+        handler = TrivyHandler({})
+        handler._trivy_runable = MagicMock(return_value=True)
+        handler._handle_results = MagicMock()
+        handler._scan("/path/to/definition")
+        mock_pipe_exec.assert_called_with(
+            "/usr/bin/trivy --quiet fs --scanners misconfig,secret --skip-dirs **/examples --cache-dir /tmp/trivy_cache --severity HIGH,CRITICAL --exit-code 1 .",
+            stream_output=True,
+            cwd="/path/to/definition",
+        )
+        handler._handle_results.assert_called_with(0, "stdout", "stderr", None)
+
+    @patch("tfworker.handlers.trivy.pipe_exec")
+    @patch("tfworker.handlers.trivy.click")
+    def test__scan_plan_success_with_options(self, mock_click, mock_pipe_exec):
+        config = {
+            "path": "/path/to/trivy",
+            "exit_code": "2",
+            "skip_dirs": [],
+            "severity": "CRITICAL",
+            "cache_dir": "/path/to/cache",
+            "stream_output": True,
+            "quiet": False,
+            "debug": True,
+            "stream_output": False,
+            "format": "template",
+            "template": "template",
+            "args": {"arg1": "value1", "arg2": "value2"},
+        }
+
+        mock_pipe_exec.return_value = (0, "stdout", "stderr")
+        handler = TrivyHandler(config)
+        handler._trivy_runable = MagicMock(return_value=True)
+        handler._handle_results = MagicMock()
+        handler._scan("/path/to/definition")
+        mock_pipe_exec.assert_called_with(
+            "/path/to/trivy --debug fs --scanners misconfig,secret --cache-dir /path/to/cache --severity CRITICAL --exit-code 2 --format template --template template --arg1 value1 --arg2 value2 .",
+            stream_output=False,
+            cwd="/path/to/definition",
+        )
+        handler._handle_results.assert_called_with(0, "stdout", "stderr", None)
+
+    @patch("tfworker.handlers.trivy.pipe_exec")
+    @patch("tfworker.handlers.trivy.click")
+    def test__scan_planfile_success_with_defaults(self, mock_click, mock_pipe_exec):
+        mock_pipe_exec.return_value = (0, "stdout", "stderr")
+        handler = TrivyHandler({})
+        handler._trivy_runable = MagicMock(return_value=True)
+        handler._handle_results = MagicMock()
+        handler._scan("/path/to/definition", Path("/path/to/planfile"))
+        mock_pipe_exec.assert_called_with(
+            "/usr/bin/trivy --quiet config --cache-dir /tmp/trivy_cache --severity HIGH,CRITICAL --exit-code 1 /path/to/planfile",
+            stream_output=True,
+            cwd="/path/to/definition",
+        )
+        handler._handle_results.assert_called_with(
+            0, "stdout", "stderr", Path("/path/to/planfile")
+        )
+
+    @patch("tfworker.handlers.trivy.pipe_exec")
+    @patch("tfworker.handlers.trivy.click")
+    def test__scan_planfile_success_with_options(self, mock_click, mock_pipe_exec):
+        config = {
+            "path": "/path/to/trivy",
+            "exit_code": "2",
+            "skip_dirs": [],
+            "severity": "CRITICAL",
+            "cache_dir": "/path/to/cache",
+            "stream_output": True,
+            "quiet": False,
+            "debug": True,
+            "stream_output": False,
+            "format": "template",
+            "template": "template",
+            "args": {"arg1": "value1", "arg2": "value2"},
+        }
+
+        mock_pipe_exec.return_value = (0, "stdout", "stderr")
+        handler = TrivyHandler(config)
+        handler._trivy_runable = MagicMock(return_value=True)
+        handler._handle_results = MagicMock()
+        handler._scan("/path/to/definition", Path("/path/to/planfile"))
+        mock_pipe_exec.assert_called_with(
+            "/path/to/trivy --debug config --cache-dir /path/to/cache --severity CRITICAL --exit-code 2 --format template --template template --arg1 value1 --arg2 value2 /path/to/planfile",
+            stream_output=False,
+            cwd="/path/to/definition",
+        )
+        handler._handle_results.assert_called_with(
+            0, "stdout", "stderr", Path("/path/to/planfile")
+        )
+
+    @patch("tfworker.handlers.trivy.pipe_exec")
+    @patch("tfworker.handlers.trivy.click")
+    def test__scan_failure(self, mock_click, mock_pipe_exec):
+        mock_pipe_exec.side_effect = Exception("error")
+        handler = TrivyHandler({})
+        handler._trivy_runable = MagicMock(return_value=True)
+        handler._handle_results = MagicMock()
+        with self.assertRaises(HandlerError):
+            handler._scan("/path/to/definition")
+        handler._handle_results.assert_not_called()
+
+
+class TestTrivyHandlerHandleResults(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def trivy_runnable_patcher(self):
+        patcher = patch("tfworker.handlers.trivy.TrivyHandler._trivy_runable")
+        mock_trivy_runable = patcher.start()
+        mock_trivy_runable.return_value = True
+        yield mock_trivy_runable
+
+    @patch("tfworker.handlers.trivy.click")
+    def test__handle_results_success(self, mock_click):
+        handler = TrivyHandler({})
+        handler._handle_results(0, "stdout".encode(), "stderr".encode(), None)
+        mock_click.secho.assert_not_called()
+
+    @patch("tfworker.handlers.trivy.click")
+    def test__handle_results_failure(self, mock_click):
+        handler = TrivyHandler({})
+        handler._handle_results(1, "stdout".encode(), "stderr".encode(), None)
+        mock_click.secho.assert_called_with(
+            "trivy scan failed with exit code 1", fg="red"
+        )
+        mock_click.secho.assert_called_once()
+
+    @patch("tfworker.handlers.trivy.click")
+    @patch("tfworker.handlers.trivy.strip_ansi")
+    def test__handle_results_failure_stream_output(self, mock_strip_ansi, mock_click):
+        handler = TrivyHandler({"stream_output": False})
+        mock_strip_ansi.side_effect = MagicMock(
+            side_effect=lambda x: x.decode("UTF-8") if isinstance(x, bytes) else x
+        )
+        handler._handle_results(1, "stdout".encode(), "stderr".encode(), None)
+        calls = [
+            call("trivy scan failed with exit code 1", fg="red"),
+            call("stdout: stdout", fg="red"),
+            call("stderr: stderr", fg="red"),
+        ]
+        mock_click.secho.assert_has_calls(calls)
+
+    @patch("tfworker.handlers.trivy.click")
+    def test__handle_results_required(self, mock_click):
+        handler = TrivyHandler({"required": True})
+        with self.assertRaises(HandlerError):
+            handler._handle_results(1, "stdout".encode(), "stderr".encode(), None)
+
+    @patch("tfworker.handlers.trivy.click")
+    @patch("os.remove")
+    def test__handle_results_remove_planfile(self, mock_remove, mock_click):
+        handler = TrivyHandler({"required": True})
+        with self.assertRaises(HandlerError):
+            handler._handle_results(
+                1, "stdout".encode(), "stderr".encode(), "/path/to/planfile"
+            )
+        mock_remove.assert_called_with("/path/to/planfile")
+
+
+class TestTrivyHandlerRaiseIfNotReady(unittest.TestCase):
+    def test__raise_if_not_ready_ready(self):
+        handler = TrivyHandler({})
+        handler._ready = True
+        result = handler._raise_if_not_ready()
+        self.assertIsNone(result)
+
+    def test__raise_if_not_ready_not_ready(self):
+        handler = TrivyHandler({"required": False})
+        handler._ready = False
+        with self.assertRaises(HandlerError) as e:
+            handler._raise_if_not_ready()
+            self.assertFalse(e.terminate)
+
+    def test__raise_if_not_ready_required(self):
+        handler = TrivyHandler({"required": True})
+        handler._ready = False
+        with self.assertRaises(HandlerError) as e:
+            handler._raise_if_not_ready()
+            self.assertTrue(e.terminate)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tfworker/commands/base.py
+++ b/tfworker/commands/base.py
@@ -128,6 +128,7 @@ class BaseCommand:
                 raise SystemExit(1)
 
         # initialize handlers collection
+        click.secho("Initializing handlers", fg="green")
         try:
             self._handlers = HandlersCollection(rootc.handlers_odict)
         except (UnknownHandler, HandlerError, TypeError) as e:
@@ -137,6 +138,11 @@ class BaseCommand:
         # allow a backend to implement handlers as well since they already control the provider session
         if self._backend.handlers and self._backend_plans:
             self._handlers.update(self._backend.handlers)
+
+        # list enabled handlers
+        click.secho("Enabled handlers:", fg="green")
+        for h in self._handlers:
+            click.secho(f"  {h}", fg="green")
 
     @property
     def authenticators(self):

--- a/tfworker/definitions.py
+++ b/tfworker/definitions.py
@@ -96,6 +96,10 @@ class Definition:
         return self._path
 
     @property
+    def fs_path(self):
+        return Path(f"{self._temp_dir}/definitions/{self.tag}").resolve()
+
+    @property
     def provider_names(self):
         """Extract only the providers used by a definition"""
         result = set(self._providers.keys())

--- a/tfworker/handlers/__init__.py
+++ b/tfworker/handlers/__init__.py
@@ -3,6 +3,7 @@ import collections
 from .base import BaseHandler
 from .bitbucket import BitbucketHandler
 from .exceptions import HandlerError, UnknownHandler
+from .trivy import TrivyHandler
 
 
 class HandlersCollection(collections.abc.Mapping):
@@ -21,6 +22,8 @@ class HandlersCollection(collections.abc.Mapping):
                 raise TypeError(f"Duplicate handler: {k}")
             if k == "bitbucket":
                 self._handlers["bitbucket"] = BitbucketHandler(handlers_config[k])
+            elif k == "trivy":
+                self._handlers["trivy"] = TrivyHandler(handlers_config[k])
             else:
                 raise UnknownHandler(provider=k)
 

--- a/tfworker/handlers/base.py
+++ b/tfworker/handlers/base.py
@@ -23,3 +23,6 @@ class BaseHandler(metaclass=ABCMeta):
             kwargs: any additional arguments that may be required
         """
         pass
+
+    def __str__(self):
+        return self.__class__.__name__

--- a/tfworker/handlers/base.py
+++ b/tfworker/handlers/base.py
@@ -7,10 +7,12 @@ class BaseHandler(metaclass=ABCMeta):
     actions = []
     required_vars = []
 
-    @abstractmethod
     def is_ready(self):  # pragma: no cover
         """is_ready is called to determine if a handler is ready to be executed"""
-        return True
+        try:
+            return self._ready
+        except AttributeError:
+            return False
 
     @abstractmethod
     def execute(self, action: str, stage: str, **kwargs) -> None:  # pragma: no cover
@@ -21,23 +23,3 @@ class BaseHandler(metaclass=ABCMeta):
             kwargs: any additional arguments that may be required
         """
         pass
-
-
-class UnknownHandler(Exception):
-    """This is an excpetion that indicates configuration was attempted for a handler that is not supported."""
-
-    def __init__(self, provider):
-        self.provider = provider
-
-    def __str__(self):
-        return f"Unknown handler: {self.provider}"
-
-
-class HandlerError(Exception):
-    """This is an exception that indicates an error occurred while attempting to execute a handler."""
-
-    def __init__(self, message):
-        self.message = message
-
-    def __str__(self):
-        return f"Handler error: {self.message}"

--- a/tfworker/handlers/exceptions.py
+++ b/tfworker/handlers/exceptions.py
@@ -3,10 +3,10 @@ class UnknownHandler(Exception):
     This is an excpetion that indicates configuration was attempted for a handler that is not supported.
     """
 
-    def __init__(self, provider):
+    def __init__(self, provider: str) -> None:
         self.provider = provider
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Unknown handler: {self.provider}"
 
 
@@ -15,8 +15,9 @@ class HandlerError(Exception):
     This is an exception that indicates an error occurred while attempting to execute a handler.
     """
 
-    def __init__(self, message):
+    def __init__(self, message: str, terminate: bool = True) -> None:
         self.message = message
+        self.terminate = terminate
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Handler error: {self.message}"

--- a/tfworker/handlers/trivy.py
+++ b/tfworker/handlers/trivy.py
@@ -1,0 +1,233 @@
+import os
+from pathlib import Path
+
+import click
+import yaml
+
+from ..util.system import pipe_exec, strip_ansi
+from .base import BaseHandler
+from .exceptions import HandlerError
+
+
+class TrivyHandler(BaseHandler):
+    """
+    The TrivyHandler will execute a trivy scan on a specified terraform plan file
+    """
+
+    actions = ["plan"]
+
+    defaults = {
+        "args": {},
+        "cache_dir": "/tmp/trivy_cache",
+        "debug": False,
+        "exit_code": "1",
+        "format": None,
+        "handler_debug": False,
+        "path": "/usr/bin/trivy",
+        "quiet": True,
+        "required": False,
+        "severity": "HIGH,CRITICAL",
+        "skip_dirs": ["**/examples"],
+        "template": '\'ERRORS: {{ range . }}{{ range .Misconfigurations}}{{ .Severity }} - {{ .ID }} - {{ .AVDID }} - {{ .Title -}} - {{ .Description }} - {{ .Message }} - {{ .Resolution }} - {{ .PrimaryURL }} - {{ range .References }}{{ . }}{{ end }}{{ "\\n" }}{{ end }}{{ "\\n" }}{{ end }}{{ "\\n" }}\'',
+        "skip_planfile": False,
+        "skip_definition": False,
+        "stream_output": True,
+    }
+
+    def __init__(self, kwargs):
+        self._ready = False
+
+        # configure the handler
+        for k in self.defaults:
+            if k in kwargs:
+                setattr(self, f"_{k}", kwargs[k])
+            else:
+                setattr(self, f"_{k}", self.defaults[k])
+
+        # ensure trivy is runnable
+        if not self._trivy_runable(self._path):
+            raise HandlerError(f"Trivy is not runnable at {self._path}")
+
+        self._ready = True
+
+    def execute(
+        self,
+        action: str,
+        stage: str,
+        planfile: str = None,
+        definition_path: Path = None,
+        changes: bool = False,
+        **kwargs,
+    ) -> None:
+        """execute is called when a handler should trigger, if this is run post plan
+        and there are changes, a scan will be executed
+
+        Parameters:
+            action (str): the action that triggered the handler (one of plan, clean, apply, destroy)
+            stage (str): the stage of the action (one of pre, post)
+            planfile (str): the path to the terraform plan file
+            definition_path (pathlib.Path): the path to the terraform definition
+            changes (bool): True if there are changes, otherwise False
+            kwargs: any additional arguments that may be passed (and ignored)
+
+        Returns:
+            None
+        """
+        # pre plan; trivy scan the definition if its applicable
+        if action == "plan" and stage == "pre":
+            if definition_path is None:
+                raise HandlerError(
+                    "definition_path is not provided, can't scan",
+                    terminate=self._required,
+                )
+
+            if self._skip_definition:
+                click.secho("Skipping trivy scan of definition", fg="yellow")
+                return None
+
+            click.secho(
+                f"scanning definition with trivy: {definition_path}", fg="green"
+            )
+            self._scan(definition_path)
+
+        # post plan; trivy scan the planfile if its applicable
+        if action == "plan" and stage == "post" and changes:
+            if planfile is None:
+                raise HandlerError(
+                    "planfile is not provided, can't scan", terminate=self._required
+                )
+
+            if definition_path is None:
+                raise HandlerError(
+                    "definition_path is not provided, can't scan",
+                    terminate=self._required,
+                )
+
+            if self._skip_planfile:
+                click.secho("Skipping trivy scan of planfile", fg="yellow")
+                return None
+
+            click.secho(f"scanning planfile with trivy: {planfile}", fg="green")
+            self._scan(definition_path, planfile)
+
+    def _scan(self, definition_path: Path, planfile: Path = None):
+        """_scan will execute a trivy scan on the provided planfile
+
+        Parameters:
+            definition_path (pathlib.Path): the path to the terraform definition
+            planfile (str): the path to the terraform plan file
+
+        Returns:
+            None
+        """
+        # The ordering of items added to the list is important, don't change it without careful consideration
+        self._raise_if_not_ready()
+
+        trivy_args = []
+        trivy_args.append(self._path)
+
+        if self._quiet:
+            trivy_args.append("--quiet")
+
+        if self._debug:
+            trivy_args.append("--debug")
+
+        if planfile is None:
+            trivy_args.append("fs")
+            trivy_args.append("--scanners")
+            trivy_args.append("misconfig,secret")
+            if len(self._skip_dirs) > 0:
+                trivy_args.append("--skip-dirs")
+                trivy_args.append(",".join(self._skip_dirs))
+        else:
+            trivy_args.append("config")
+
+        trivy_args.append("--cache-dir")
+        trivy_args.append(self._cache_dir)
+        trivy_args.append("--severity")
+        trivy_args.append(self._severity)
+        trivy_args.append("--exit-code")
+        trivy_args.append(self._exit_code)
+
+        if self._format:
+            trivy_args.append("--format")
+            trivy_args.append(self._format)
+
+            if self._format == "template":
+                trivy_args.append("--template")
+                trivy_args.append(self._template)
+
+        for k, v in self._args.items():
+            trivy_args.append(f"--{k}")
+            trivy_args.append(v)
+
+        if planfile is not None:
+            trivy_args.append(str(Path.resolve(planfile)))
+        else:
+            trivy_args.append(".")
+
+        try:
+            if self._debug:
+                click.secho(f"cmd: {' '.join(trivy_args)}", fg="yellow")
+            (exit_code, stdout, stderr) = pipe_exec(
+                f"{' '.join(trivy_args)}",
+                cwd=str(definition_path),
+                stream_output=self._stream_output,
+            )
+        except Exception as e:
+            raise HandlerError(f"Error executing trivy scan: {e}")
+
+        self._handle_results(exit_code, stdout, stderr, planfile)
+
+    def _handle_results(self, exit_code, stdout, stderr, planfile):
+        """_handle_results will handle the results of the trivy scan
+
+        Parameters:
+            exit_code (int): the exit code of the trivy scan
+            stdout (str): the stdout of the trivy scan
+            stderr (str): the stderr of the trivy scan
+
+        Returns:
+            None
+        """
+        if exit_code != 0:
+            click.secho(f"trivy scan failed with exit code {exit_code}", fg="red")
+            if self._stream_output is False:
+                click.secho(strip_ansi(f"stdout: {stdout.decode('UTF-8')}"), fg="red")
+                click.secho(strip_ansi(f"stderr: {stderr.decode('UTF-8')}"), fg="red")
+
+            if self._required:
+                if planfile is not None:
+                    click.secho(f"Removing planfile: {planfile}", fg="yellow")
+                    os.remove(planfile)
+                raise HandlerError(
+                    f"trivy scan required; aborting execution", terminate=True
+                )
+
+    def _raise_if_not_ready(self):
+        """_raise_if_not_ready will raise a HandlerError if the handler is not ready
+
+        Returns:
+            None
+        """
+        if not self.is_ready():
+            raise HandlerError(
+                "Trivy handler is not ready to execute", terminate=self._required
+            )
+
+    @staticmethod
+    def _trivy_runable(path):
+        """_trivy_runable is a static method that checks if the trivy binary is runnable
+
+        Parameters:
+            path (str): the path to the trivy binary
+
+        Returns:
+            bool: True if the trivy binary is runnable, otherwise False
+        """
+
+        if not os.path.exists(path):
+            return False
+        if not os.access(path, os.X_OK):
+            return False
+        return True


### PR DESCRIPTION
- update .tf test fixtures to be valid terraform to stop language server from complaining
- add tests for handlers.exceptions
- add tests for handlers.trivy (100% coverage)
- provide additional arguments to handler calls in tfworker/commands/terraform.py
- print enabled handlers to console output
- make termination of tfworker run on handler errors optional
- add the trivy handler
  - highly configurable to tailor trivy scans for different use cases
  - scans definition after init, before planning if enabled
  - scans .tfplan files, after planning if enabled
- improve type hinting throughout handlers base classes