### PR TITLE
Change the .tfvars file name

### DIFF
--- a/tfworker/constants.py
+++ b/tfworker/constants.py
@@ -30,7 +30,7 @@ TF_PROVIDER_DEFAULT_LOCKFILE = ".terraform.lock.hcl"
 TF_STATE_CACHE_NAME = "worker_state_cache.json"
 WORKER_LOCALS_FILENAME = "worker_generated_locals.tf"
 WORKER_TF_FILENAME = "worker_generated_terraform.tf"
-WORKER_TFVARS_FILENAME = "worker_generated.tfvars"
+WORKER_TFVARS_FILENAME = "worker_generated.auto.tfvars"
 RESERVED_FILES = [
     WORKER_LOCALS_FILENAME,
     WORKER_TF_FILENAME,


### PR DESCRIPTION
In order to be loaded without a -var parameter, the file needs to end with .auto.tfvars. This was changed when moving the value to a constant, in order to try and be more consistent and predictable.