### PR TITLE
DEVOPS-8246: Change error to warning when remote state can not be refreshed

### DIFF
--- a/tfworker/util/hooks.py
+++ b/tfworker/util/hooks.py
@@ -543,8 +543,7 @@ def _run_terraform_refresh(
         env=env,
     )
     if exit_code != 0:
-        raise HookError(f"Error applying terraform state, details: {stderr}")
-
+        log.warn(f"Could not refresh remote state, hook script may have unexpected results")
 
 def _run_terraform_show(
     terraform_bin: str, working_dir: str, env: Dict[str, str]


### PR DESCRIPTION
This is not necessarily an error, but it is a condition that the user should know about.  This is an edge case triggered by a definition that has remote variable references setup, and also generates dynamic .tf code.