### PR TITLE
Add provider "alias" support, and cleanup format/lint issues

### DIFF
--- a/tests/definitions/test_definitions_prepare.py
+++ b/tests/definitions/test_definitions_prepare.py
@@ -1,14 +1,6 @@
 import pytest
 from tfworker.definitions import Definition, DefinitionsCollection
-from tfworker.definitions.prepare import (
-    DefinitionPrepare,
-    copy,
-    filter_templates,
-    get_coppier,
-    get_jinja_env,
-    vars_typer,
-    write_template_file,
-)
+from tfworker.definitions.prepare import DefinitionPrepare
 from tfworker.exceptions import ReservedFileError, TFWorkerException
 
 

--- a/tfworker/cli.py
+++ b/tfworker/cli.py
@@ -109,7 +109,7 @@ def terraform(ctx: click.Context, deployment: str, **kwargs):
 @cli.command()
 @click.argument("deployment", envvar="WORKER_DEPLOYMENT", callback=validate_deployment)
 @click.pass_context
-def env(ctx: click.Context, deployment:str, **kwargs):
+def env(ctx: click.Context, deployment: str, **kwargs):
     """
     Export environment variables for the configured backend
 

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -94,9 +94,7 @@ class TerraformCommand(BaseCommand):
         # check for existing plan files that need an apply
         for name in self.app_state.definitions.keys():
             def_plan.set_plan_file(self.app_state.definitions[name])
-            needed, reason = def_plan.needs_plan(
-                self.app_state.definitions[name]
-            )
+            needed, reason = def_plan.needs_plan(self.app_state.definitions[name])
             if not needed:
                 if "plan file exists" in reason:
                     for name in self.app_state.definitions.keys():

--- a/tfworker/definitions/model.py
+++ b/tfworker/definitions/model.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 
 import tfworker.util.log as log
 from pydantic import BaseModel, ConfigDict, Field

--- a/tfworker/providers/collection.py
+++ b/tfworker/providers/collection.py
@@ -113,6 +113,7 @@ class ProvidersCollection(Mapping):
         Returns:
             str: HCL code for the specified providers.
         """
+        log.trace(f"Generating HCL for providers: {includes}")
         if includes is None:
             includes = list(self._providers.keys())
 

--- a/tfworker/util/hooks.py
+++ b/tfworker/util/hooks.py
@@ -543,7 +543,10 @@ def _run_terraform_refresh(
         env=env,
     )
     if exit_code != 0:
-        log.warn(f"Could not refresh remote state, hook script may have unexpected results")
+        log.warn(
+            "Could not refresh remote state, hook script may have unexpected results"
+        )
+
 
 def _run_terraform_show(
     terraform_bin: str, working_dir: str, env: Dict[str, str]


### PR DESCRIPTION
- adds the ability to include an "alias" in providers, it will copy the top level vars and config_blocks to ensure consistent configuration, and values that are specified in the alias will overwrite the top level config
- remove unused imports in several places
- fix formatting with black in several places

The new config support for specifying provider aliases looks like this: 

```
  providers:
    aws:
      aliases:
        use1:
          vars:
            region: us-east-1
      requirements:
        version: 5.50.0
      vars:
        region: us-west-2
      config_blocks:
        default_tags: {
          # these tags will be applied to all supported AWS resources with the exception of AutoScalingGroups
          tags: {
            "Terraform": "true",
            "Environment": "production",
            "Owner": "Infrastructure",
          }
        }
```

The resulting generated terraform will include provider configuration blocks for aws, both in the normal form, as well as in the form with an alias. Then the "aws.use1" provider will be available for use anywhere.