### PR TITLE
Make remote state reference handling more robust

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -502,38 +502,38 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "43.0.0"
+version = "43.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "cryptography-43.0.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:64c3f16e2a4fc51c0d06af28441881f98c5d91009b8caaff40cf3548089e9c74"},
-    {file = "cryptography-43.0.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3dcdedae5c7710b9f97ac6bba7e1052b95c7083c9d0e9df96e02a1932e777895"},
-    {file = "cryptography-43.0.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d9a1eca329405219b605fac09ecfc09ac09e595d6def650a437523fcd08dd22"},
-    {file = "cryptography-43.0.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ea9e57f8ea880eeea38ab5abf9fbe39f923544d7884228ec67d666abd60f5a47"},
-    {file = "cryptography-43.0.0-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9a8d6802e0825767476f62aafed40532bd435e8a5f7d23bd8b4f5fd04cc80ecf"},
-    {file = "cryptography-43.0.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cc70b4b581f28d0a254d006f26949245e3657d40d8857066c2ae22a61222ef55"},
-    {file = "cryptography-43.0.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4a997df8c1c2aae1e1e5ac49c2e4f610ad037fc5a3aadc7b64e39dea42249431"},
-    {file = "cryptography-43.0.0-cp37-abi3-win32.whl", hash = "sha256:6e2b11c55d260d03a8cf29ac9b5e0608d35f08077d8c087be96287f43af3ccdc"},
-    {file = "cryptography-43.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:31e44a986ceccec3d0498e16f3d27b2ee5fdf69ce2ab89b52eaad1d2f33d8778"},
-    {file = "cryptography-43.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:7b3f5fe74a5ca32d4d0f302ffe6680fcc5c28f8ef0dc0ae8f40c0f3a1b4fca66"},
-    {file = "cryptography-43.0.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac1955ce000cb29ab40def14fd1bbfa7af2017cca696ee696925615cafd0dce5"},
-    {file = "cryptography-43.0.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:299d3da8e00b7e2b54bb02ef58d73cd5f55fb31f33ebbf33bd00d9aa6807df7e"},
-    {file = "cryptography-43.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ee0c405832ade84d4de74b9029bedb7b31200600fa524d218fc29bfa371e97f5"},
-    {file = "cryptography-43.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cb013933d4c127349b3948aa8aaf2f12c0353ad0eccd715ca789c8a0f671646f"},
-    {file = "cryptography-43.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fdcb265de28585de5b859ae13e3846a8e805268a823a12a4da2597f1f5afc9f0"},
-    {file = "cryptography-43.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2905ccf93a8a2a416f3ec01b1a7911c3fe4073ef35640e7ee5296754e30b762b"},
-    {file = "cryptography-43.0.0-cp39-abi3-win32.whl", hash = "sha256:47ca71115e545954e6c1d207dd13461ab81f4eccfcb1345eac874828b5e3eaaf"},
-    {file = "cryptography-43.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:0663585d02f76929792470451a5ba64424acc3cd5227b03921dab0e2f27b1709"},
-    {file = "cryptography-43.0.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2c6d112bf61c5ef44042c253e4859b3cbbb50df2f78fa8fae6747a7814484a70"},
-    {file = "cryptography-43.0.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:844b6d608374e7d08f4f6e6f9f7b951f9256db41421917dfb2d003dde4cd6b66"},
-    {file = "cryptography-43.0.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:51956cf8730665e2bdf8ddb8da0056f699c1a5715648c1b0144670c1ba00b48f"},
-    {file = "cryptography-43.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:aae4d918f6b180a8ab8bf6511a419473d107df4dbb4225c7b48c5c9602c38c7f"},
-    {file = "cryptography-43.0.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:232ce02943a579095a339ac4b390fbbe97f5b5d5d107f8a08260ea2768be8cc2"},
-    {file = "cryptography-43.0.0-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:5bcb8a5620008a8034d39bce21dc3e23735dfdb6a33a06974739bfa04f853947"},
-    {file = "cryptography-43.0.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:08a24a7070b2b6804c1940ff0f910ff728932a9d0e80e7814234269f9d46d069"},
-    {file = "cryptography-43.0.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:e9c5266c432a1e23738d178e51c2c7a5e2ddf790f248be939448c0ba2021f9d1"},
-    {file = "cryptography-43.0.0.tar.gz", hash = "sha256:b88075ada2d51aa9f18283532c9f60e72170041bba88d7f37e49cbb10275299e"},
+    {file = "cryptography-43.0.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:8385d98f6a3bf8bb2d65a73e17ed87a3ba84f6991c155691c51112075f9ffc5d"},
+    {file = "cryptography-43.0.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27e613d7077ac613e399270253259d9d53872aaf657471473ebfc9a52935c062"},
+    {file = "cryptography-43.0.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68aaecc4178e90719e95298515979814bda0cbada1256a4485414860bd7ab962"},
+    {file = "cryptography-43.0.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:de41fd81a41e53267cb020bb3a7212861da53a7d39f863585d13ea11049cf277"},
+    {file = "cryptography-43.0.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f98bf604c82c416bc829e490c700ca1553eafdf2912a91e23a79d97d9801372a"},
+    {file = "cryptography-43.0.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:61ec41068b7b74268fa86e3e9e12b9f0c21fcf65434571dbb13d954bceb08042"},
+    {file = "cryptography-43.0.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:014f58110f53237ace6a408b5beb6c427b64e084eb451ef25a28308270086494"},
+    {file = "cryptography-43.0.1-cp37-abi3-win32.whl", hash = "sha256:2bd51274dcd59f09dd952afb696bf9c61a7a49dfc764c04dd33ef7a6b502a1e2"},
+    {file = "cryptography-43.0.1-cp37-abi3-win_amd64.whl", hash = "sha256:666ae11966643886c2987b3b721899d250855718d6d9ce41b521252a17985f4d"},
+    {file = "cryptography-43.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:ac119bb76b9faa00f48128b7f5679e1d8d437365c5d26f1c2c3f0da4ce1b553d"},
+    {file = "cryptography-43.0.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bbcce1a551e262dfbafb6e6252f1ae36a248e615ca44ba302df077a846a8806"},
+    {file = "cryptography-43.0.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d4e9129985185a06d849aa6df265bdd5a74ca6e1b736a77959b498e0505b85"},
+    {file = "cryptography-43.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d03a475165f3134f773d1388aeb19c2d25ba88b6a9733c5c590b9ff7bbfa2e0c"},
+    {file = "cryptography-43.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:511f4273808ab590912a93ddb4e3914dfd8a388fed883361b02dea3791f292e1"},
+    {file = "cryptography-43.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:80eda8b3e173f0f247f711eef62be51b599b5d425c429b5d4ca6a05e9e856baa"},
+    {file = "cryptography-43.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38926c50cff6f533f8a2dae3d7f19541432610d114a70808f0926d5aaa7121e4"},
+    {file = "cryptography-43.0.1-cp39-abi3-win32.whl", hash = "sha256:a575913fb06e05e6b4b814d7f7468c2c660e8bb16d8d5a1faf9b33ccc569dd47"},
+    {file = "cryptography-43.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:d75601ad10b059ec832e78823b348bfa1a59f6b8d545db3a24fd44362a1564cb"},
+    {file = "cryptography-43.0.1-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ea25acb556320250756e53f9e20a4177515f012c9eaea17eb7587a8c4d8ae034"},
+    {file = "cryptography-43.0.1-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c1332724be35d23a854994ff0b66530119500b6053d0bd3363265f7e5e77288d"},
+    {file = "cryptography-43.0.1-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fba1007b3ef89946dbbb515aeeb41e30203b004f0b4b00e5e16078b518563289"},
+    {file = "cryptography-43.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:5b43d1ea6b378b54a1dc99dd8a2b5be47658fe9a7ce0a58ff0b55f4b43ef2b84"},
+    {file = "cryptography-43.0.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:88cce104c36870d70c49c7c8fd22885875d950d9ee6ab54df2745f83ba0dc365"},
+    {file = "cryptography-43.0.1-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:9d3cdb25fa98afdd3d0892d132b8d7139e2c087da1712041f6b762e4f807cc96"},
+    {file = "cryptography-43.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:e710bf40870f4db63c3d7d929aa9e09e4e7ee219e703f949ec4073b4294f6172"},
+    {file = "cryptography-43.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7c05650fe8023c5ed0d46793d4b7d7e6cd9c04e68eabe5b0aeea836e37bdcec2"},
+    {file = "cryptography-43.0.1.tar.gz", hash = "sha256:203e92a75716d8cfb491dc47c79e17d0d9207ccffcbcb35f598fbe463ae3444d"},
 ]
 
 [package.dependencies]
@@ -546,7 +546,7 @@ nox = ["nox"]
 pep8test = ["check-sdist", "click", "mypy", "ruff"]
 sdist = ["build"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi", "cryptography-vectors (==43.0.0)", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test = ["certifi", "cryptography-vectors (==43.0.1)", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]

--- a/tests/util/test_util_hooks.py
+++ b/tests/util/test_util_hooks.py
@@ -60,7 +60,7 @@ class TestGetStateItem:
     def test_get_state_item_from_output_success(self, mock_remote, mock_output):
         mock_output.return_value = '{"key": "value"}'
         result = hooks.get_state_item(
-            "working_dir", {}, "terraform_bin", "state", "item"
+            "working_dir", {}, "terraform_bin", "state", "item", None
         )
         assert result == '{"key": "value"}'
         mock_output.assert_called_once()
@@ -73,7 +73,7 @@ class TestGetStateItem:
     def test_get_state_item_from_remote_success(self, mock_remote, mock_output):
         mock_remote.return_value = '{"key": "value"}'
         result = hooks.get_state_item(
-            "working_dir", {}, "terraform_bin", "state", "item"
+            "working_dir", {}, "terraform_bin", "state", "item", None
         )
         assert result == '{"key": "value"}'
         mock_output.assert_called_once()
@@ -291,7 +291,7 @@ class TestHelperFunctions:
 
         local_env = {}
         hooks._populate_environment_with_terraform_remote_vars(
-            local_env, "working_dir", "terraform_path", False
+            local_env, "working_dir", "terraform_path", False, None
         )
         assert "TF_REMOTE_LOCAL_KEY" in local_env.keys()
         assert "TF_REMOTE_LOCAL_ANOTHER_KEY" in local_env.keys()

--- a/tfworker/backends/base.py
+++ b/tfworker/backends/base.py
@@ -91,6 +91,19 @@ class BaseBackend(metaclass=ABCMeta):
         """
         pass  # pragma: no cover
 
+    @abstractmethod
+    def get_state(self, remote: str) -> JSONType:
+        """
+        Get the state file from the backend, for a remote.
+
+        Args:
+            deployment (str): The deployment name
+
+        Returns:
+            JSONType: The state from the backend
+        """
+        pass
+
 
 def validate_backend_empty(state: JSONType) -> bool:
     """

--- a/tfworker/backends/gcs.py
+++ b/tfworker/backends/gcs.py
@@ -8,6 +8,7 @@ from google.auth.exceptions import DefaultCredentialsError
 from google.cloud import storage
 from google.cloud.exceptions import Conflict, NotFound
 from tfworker.exceptions import BackendError
+from tfworker.types import JSONType
 
 from .base import BaseBackend, validate_backend_empty
 
@@ -192,3 +193,6 @@ class GCSBackend(BaseBackend):
             remote_data_config.append("  }")
             remote_data_config.append("}")
         return "\n".join(remote_data_config)
+
+    def get_state(self, remote: str) -> JSONType:
+        raise NotImplementedError

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -353,6 +353,7 @@ class TerraformCommand(BaseCommand):
                 extra_vars=definition.get_template_vars(
                     self.app_state.loaded_config.global_vars.template_vars
                 ),
+                backend=self.app_state.backend,
             )
         except HookError as e:
             log.error(f"hook execution error on definition {definition.name}: \n{e}")

--- a/tfworker/util/hooks.py
+++ b/tfworker/util/hooks.py
@@ -42,11 +42,13 @@ def get_state_item(
     terraform_bin: str,
     state: str,
     item: str,
-    backend: "BaseBackend" = None,
+    backend: "BaseBackend",
 ) -> str:
     """
     General handler function for getting a state item. First tries to get the item from another definition's output,
-    and if the other definition is not set up, falls back to getting the item from the remote state.
+    and if the other definition is not set up, falls back to getting the item from the remote state. Finally, if the
+    terraform remote can not be used, like in the case of a definition requiring a hook script in order to execute
+    `terraform`; fall back to getting the item from the remote state if the provider supports it.
 
     Args:
         working_dir (str): The working directory of the terraform definition.
@@ -61,15 +63,17 @@ def get_state_item(
     Raises:
         HookError: If the state item is not found in the remote state.
     """
-
     try:
-        log.trace(f"Getting state item {state}.{item} from output")
+        log.debug(f"Getting state item {state}.{item} from output")
         return _get_state_item_from_output(working_dir, env, terraform_bin, state, item)
     except FileNotFoundError:
         log.trace(
-            "Remote state not setup, falling back to getting state item from remote"
+            "Definition is not included in limit; falling back to remote state via terraform refresh"
         )
-        return _get_state_item_from_remote(working_dir, env, terraform_bin, state, item)
+
+    return _get_state_item_from_remote(
+        working_dir, env, terraform_bin, state, item, backend
+    )
 
 
 def _get_state_item_from_output(
@@ -163,6 +167,7 @@ def hook_exec(
     debug: bool = False,
     b64_encode: bool = False,
     extra_vars: Dict[str, str] = None,
+    backend: "BaseBackend" = None,
 ) -> None:
     """
     Coordinates the execution of a hook script. This function is responsible for finding and executing
@@ -191,7 +196,7 @@ def hook_exec(
         local_env, working_dir, terraform_path, b64_encode
     )
     _populate_environment_with_terraform_remote_vars(
-        local_env, working_dir, terraform_path, b64_encode
+        local_env, working_dir, terraform_path, b64_encode, backend
     )
     _populate_environment_with_extra_vars(local_env, extra_vars, b64_encode)
     _execute_hook_script(hook_script, phase, command, working_dir, local_env, debug)
@@ -261,7 +266,11 @@ def _populate_environment_with_terraform_variables(
 
 
 def _populate_environment_with_terraform_remote_vars(
-    local_env: Dict[str, str], working_dir: str, terraform_path: str, b64_encode: bool
+    local_env: Dict[str, str],
+    working_dir: str,
+    terraform_path: str,
+    b64_encode: bool,
+    backend: "BaseBackend",
 ) -> None:
     """
     Populates the environment with Terraform variables.
@@ -292,7 +301,7 @@ def _populate_environment_with_terraform_remote_vars(
             state = m.group("state")
             state_item = m.group("state_item")
             state_value = get_state_item(
-                working_dir, local_env, terraform_path, state, state_item
+                working_dir, local_env, terraform_path, state, state_item, backend
             )
             _set_hook_env_var(
                 local_env, TFHookVarType.REMOTE, item, state_value, b64_encode
@@ -398,7 +407,12 @@ def _execute_hook_script(
 
 
 def _get_state_item_from_remote(
-    working_dir: str, env: Dict[str, str], terraform_bin: str, state: str, item: str
+    working_dir: str,
+    env: Dict[str, str],
+    terraform_bin: str,
+    state: str,
+    item: str,
+    backend: "BaseBackend",
 ) -> str:
     """
     Retrieve a state item from terraform remote state.
@@ -416,16 +430,14 @@ def _get_state_item_from_remote(
     Raises:
         HookError: If the state item cannot be found or read.
     """
-    cache_file = _get_state_cache_name(working_dir)
-    _make_state_cache(working_dir, env, terraform_bin)
-
+    cache_file = _make_state_cache(working_dir, env, terraform_bin, state, backend)
     state_cache = _read_state_cache(cache_file)
     remote_state = _find_remote_state(state_cache, state)
 
     return _get_item_from_remote_state(remote_state, state, item)
 
 
-def _get_state_cache_name(working_dir: str) -> str:
+def _get_state_cache_name(working_dir: str, state: str | None = None) -> str:
     """
     Get the name of the state cache file.
 
@@ -435,12 +447,20 @@ def _get_state_cache_name(working_dir: str) -> str:
     Returns:
         str: The name of the state cache file.
     """
+    log.trace(f"Getting state cache name for {working_dir}")
+    if state:
+        return f"{working_dir}/{state}_{TF_STATE_CACHE_NAME}"
     return f"{working_dir}/{TF_STATE_CACHE_NAME}"
 
 
 def _make_state_cache(
-    working_dir: str, env: Dict[str, str], terraform_bin: str, refresh: bool = False
-) -> None:
+    working_dir: str,
+    env: Dict[str, str],
+    terraform_bin: str,
+    state: str,
+    backend: "BaseBackend",
+    refresh: bool = False,
+) -> str:
     """
     Create a cache of the terraform state file.
 
@@ -454,12 +474,27 @@ def _make_state_cache(
         HookError: If there is an error reading or writing the state cache.
     """
     state_cache = _get_state_cache_name(working_dir)
+    log.trace(f"Creating state cache for {working_dir}")
     if not refresh and os.path.exists(state_cache):
-        return
+        log.trace("State cache exists, skipping refresh")
+        return state_cache
 
-    _run_terraform_refresh(terraform_bin, working_dir, env)
-    state_json = _run_terraform_show(terraform_bin, working_dir, env)
-    _write_state_cache(state_cache, state_json)
+    try:
+        _run_terraform_refresh(terraform_bin, working_dir, env)
+        state_json = _run_terraform_show(terraform_bin, working_dir, env)
+        _write_state_cache(state_cache, state_json)
+        return state_cache
+    except HookError:
+        log.trace("making state cache from terraform refresh failed")
+
+    if backend:
+        try:
+            state_cache = _get_state_cache_name(working_dir, state)
+            state_json = json.dumps(backend.get_state(state))
+            _write_state_cache(state_cache, state_json)
+            return state_cache
+        except NotImplementedError:
+            raise HookError("all methods to make the state cache failed")
 
 
 def _read_state_cache(cache_file: str) -> Dict[str, Any]:
@@ -490,10 +525,22 @@ def _find_remote_state(state_cache: Dict[str, Any], state: str) -> Dict[str, Any
     Raises:
         HookError: If the remote state is not found in the state cache.
     """
-    resources = state_cache["values"]["root_module"]["resources"]
-    for resource in resources:
-        if resource["type"] == "terraform_remote_state" and resource["name"] == state:
-            return resource
+
+    # If values is a key, then we need to extract the remote state item from the root module
+    if "values" in state_cache:
+        resources = state_cache["values"]["root_module"]["resources"]
+        for resource in resources:
+            if (
+                resource["type"] == "terraform_remote_state"
+                and resource["name"] == state
+            ):
+                return resource
+
+    # Otherwise the cache is a root state, and we just need to return the entire state_cache in a dict
+    # with a first key of "values"
+    if "lineage" in state_cache:
+        return {"values": state_cache}
+
     raise HookError(f"Remote state item {state} not found")
 
 
@@ -537,15 +584,14 @@ def _run_terraform_refresh(
     Raises:
         HookError: If there is an error refreshing the terraform state.
     """
+    log.trace(f"Refreshing remote state for {working_dir}")
     exit_code, _, stderr = pipe_exec(
         f"{terraform_bin} apply -auto-approve -refresh-only",
         cwd=working_dir,
         env=env,
     )
     if exit_code != 0:
-        log.warn(
-            "Could not refresh remote state, hook script may have unexpected results"
-        )
+        raise HookError(f"Error refreshing terraform state, details: {stderr}")
 
 
 def _run_terraform_show(


### PR DESCRIPTION
In the event where a hook script execution is required in order to make terraform
execute in order to show the state (such as when a hook script defines the value of
specific variables) there is a circular condition where the remote outputs can not
be determined by terraform directly, and still made available to the hook.

In order to work around this issue, when the two initial mechanisms to get remote
state items fail, then the state is acquired from the backend (currently only S3
supported), and the state of the remote reference is used directly to obtain the
values.

This PR also updates dependencies to address https://github.com/advisories/GHSA-7m4m-pwhv-49c5