### PR TITLE
Add support for Terraform --target flag with validation and plan-time integration

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1949,18 +1949,23 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "70.3.0"
+version = "78.1.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc"},
-    {file = "setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5"},
+    {file = "setuptools-78.1.1-py3-none-any.whl", hash = "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561"},
+    {file = "setuptools-78.1.1.tar.gz", hash = "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d"},
 ]
 
 [package.extras]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.10.0)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)", "ruff (>=0.8.0)"]
+core = ["importlib_metadata (>=6)", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
+type = ["importlib_metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.14.*)", "pytest-mypy"]
 
 [[package]]
 name = "six"
@@ -2343,4 +2348,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "abdaa04cd2215b9c2969684444987d76d90af7e7a01489acdbf0e43ea4196666"
+content-hash = "62ac9918e041ffb709b6cf4ef040938f826b4d151e83aee0d610dae7569e7bf2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ mergedeep = "^1.3"
 pydantic = "^2.7"
 python-hcl2 = "^4.3"
 pyyaml = "^6.0"
-setuptools = "^70.0"
+setuptools = "^78.1"
 pydantic-settings = "^2.3.4"
 packaging = "^24.1"
 

--- a/tests/handlers/test_snyk_scan.py
+++ b/tests/handlers/test_snyk_scan.py
@@ -133,8 +133,7 @@ class TestSnykHandler:
     def test_execute_pre_plan_fail(self):
         # Mock out the snyk call with a failure script
         shutil.copy(Path(mock_snyk_failure_path), Path(snyk_path))
-
-        config = SnykConfig(path=snyk_path, required=True)
+        config = SnykConfig(path=snyk_path, required=True, skip_definition=False)
 
         with pytest.raises(HandlerError):
             SnykHandler(config).execute(
@@ -170,11 +169,12 @@ class TestSnykHandler:
         # Mock out the snyk call with a faliure script
         # We want to ensure it got called, so we'll expect the failure as an exception
         shutil.copy(Path(mock_snyk_failure_path), Path(snyk_path))
+        Path(snyk_path).chmod(0o755)
 
         result = TerraformResult(
             2, "Plan has changes".encode("utf-8"), "".encode("utf-8")
         )
-        config = SnykConfig(path=snyk_path, required=True)
+        config = SnykConfig(path=snyk_path, required=True, skip_definition=False)
         handler = SnykHandler(config)
 
         with pytest.raises(HandlerError):

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -324,6 +324,32 @@ class TestCLIOptionsTerraform:
         with pytest.raises(ValueError):
             c.CLIOptionsTerraform(limit=["module1", "module2"])
 
+    def test_validate_target_with_plan_enabled(self):
+        cli_options = c.CLIOptionsTerraform(target=["module.resource"], plan=True)
+        assert cli_options.target == ["module.resource"]
+
+    def test_validate_target_with_plan_default(self):
+        cli_options = c.CLIOptionsTerraform(target=["module.resource"])
+        assert cli_options.target == ["module.resource"]
+
+    def test_validate_target_with_no_plan(self):
+        with pytest.raises(ValueError):
+            c.CLIOptionsTerraform(target=["module.resource"], plan=False)
+
+    def test_validate_target_csv(self):
+        cli_options = c.CLIOptionsTerraform(target="module1.resource,module2.resource")
+        assert sorted(cli_options.target) == sorted(
+            ["module1.resource", "module2.resource"]
+        )
+
+    def test_validate_target_csv_in_list(self):
+        cli_options = c.CLIOptionsTerraform(
+            target=["module1.resource,module2.resource", "module3.resource"]
+        )
+        assert sorted(cli_options.target) == sorted(
+            ["module1.resource", "module2.resource", "module3.resource"]
+        )
+
 
 class TestCLIOptionsClean:
     """

--- a/tests/util/test_util_hooks.py
+++ b/tests/util/test_util_hooks.py
@@ -236,7 +236,6 @@ class TestHookExec:
         mock_execute.assert_called_once()
 
 
-
 # Helper function tests
 class TestHelperFunctions:
     @mock.patch(

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -515,7 +515,7 @@ class TerraformCommandConfig:
         target_args = ""
         if command == TerraformAction.PLAN and self._app_state.terraform_options.target:
             target_args = " " + " ".join(
-                f"--target={shlex_quote(quote_index_brackets(target))}"
+                f"-target={shlex_quote(quote_index_brackets(target))}"
                 for target in self._app_state.terraform_options.target
             )
 

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from shlex import quote as shlex_quote
 from typing import TYPE_CHECKING, Dict, Union
 
 import tfworker.util.hooks as hooks
@@ -9,6 +10,7 @@ from tfworker.commands.base import BaseCommand
 from tfworker.definitions import Definition
 from tfworker.exceptions import HandlerError, HookError, TFWorkerException
 from tfworker.types.terraform import TerraformAction, TerraformStage
+from tfworker.util.terraform import quote_index_brackets
 from tfworker.util.system import pipe_exec
 
 if TYPE_CHECKING:
@@ -241,6 +243,12 @@ class TerraformCommand(BaseCommand):
         definition: Definition = self.app_state.definitions[name]
 
         log.trace(f"running terraform plan for definition {name}")
+
+        if self._app_state.terraform_options.target:
+            log.info(
+                f"targeting resources: {', '.join(self._app_state.terraform_options.target)}"
+            )
+
         result = self._run(name, TerraformAction.PLAN)
 
         if result.exit_code == 0:
@@ -318,7 +326,7 @@ class TerraformCommand(BaseCommand):
             f"handling terraform command: {action} for definition {definition_name}"
         )
         definition: Definition = self.app_state.definitions[definition_name]
-        params: dict = self.terraform_config.get_params(
+        params: str = self.terraform_config.get_params(
             action, plan_file=definition.plan_file
         )
 
@@ -504,9 +512,16 @@ class TerraformCommandConfig:
         plan_action = " -destroy" if self.action == TerraformAction.DESTROY else ""
         read_only = "-lockfile=readonly" if self.strict_locking else ""
 
+        target_args = ""
+        if command == TerraformAction.PLAN and self._app_state.terraform_options.target:
+            target_args = " " + " ".join(
+                f"--target={shlex_quote(quote_index_brackets(target))}"
+                for target in self._app_state.terraform_options.target
+            )
+
         return {
             TerraformAction.INIT: f"-input=false {color_str} {read_only} -plugin-dir={self._app_state.terraform_options.provider_cache}",
-            TerraformAction.PLAN: f"-input=false {color_str} {plan_action} -detailed-exitcode -out {plan_file}",
+            TerraformAction.PLAN: f"-input=false {color_str} {plan_action} -detailed-exitcode -out {plan_file}{target_args}",
             TerraformAction.APPLY: f"-input=false {color_str} -auto-approve {plan_file}",
             TerraformAction.DESTROY: f"-input=false {color_str} -auto-approve",
         }[command]

--- a/tfworker/handlers/snyk.py
+++ b/tfworker/handlers/snyk.py
@@ -168,11 +168,15 @@ class SnykHandler(BaseHandler):
         Returns:
             None
         """
+        if exit_code == 0:
+            log.debug(f"snyk scan exit code: {exit_code}")
+            log.debug(f"stdout: {stdout.decode('UTF-8')}")
+            log.debug(f"stderr: {stderr.decode('UTF-8')}")
+
         if exit_code != 0:
             log.error(f"snyk scan failed with exit code {exit_code}")
-            if self._stream_output is False:
-                log.error(f"stdout: {stdout.decode('UTF-8')}")
-                log.error(f"stderr: {stderr.decode('UTF-8')}")
+            log.error(f"stdout: {stdout.decode('UTF-8')}")
+            log.error(f"stderr: {stderr.decode('UTF-8')}")
 
             if self._required:
                 planfile = definition.plan_file

--- a/tfworker/util/terraform.py
+++ b/tfworker/util/terraform.py
@@ -189,3 +189,7 @@ def find_required_providers(
     if len(required_providers) == 0:
         return None
     return required_providers
+
+@lru_cache
+def quote_index_brackets(resource: str) -> str:
+    return re.sub(r'\[([^\[\]"]+)\]', r'["\1"]', resource)


### PR DESCRIPTION
This update introduces support for passing targeted Terraform resources via the --target flag. Targeting is limited to the plan phase, consistent with Terraform’s behavior, and is validated accordingly.

Key Changes:
	•	Added target option to CLIOptionsTerraform, allowing repeated or comma-separated values.
	•	Validation logic ensures --target cannot be used with --no-plan.
	•	TerraformCommandConfig.get_params() appends --target flags only during the plan action.
	•	Informational logging added to indicate targeted resources.
	•	Tests added to verify target option behavior, including validation rules.
	•	Fixed misconfiguration in Snyk tests: skip_definition=False now correctly passed for tests that execute handlers in isolation.
	•	Improved debug/error logging in Snyk handler to capture stdout/stderr consistently.

This enables scoped execution of Terraform plans, improving precision and control in multi-resource modules.