### PR TITLE
INF-6210: Correct always_apply handling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -183,18 +183,18 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.38.36"
+version = "1.38.39"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "boto3-1.38.36-py3-none-any.whl", hash = "sha256:34c27d7317cadb62c0e9856e5d5aa0271ef47202d340584831048bc7ac904136"},
-    {file = "boto3-1.38.36.tar.gz", hash = "sha256:efe0aaa060f8fedd76e5c942055f051aee0432fc722d79d8830a9fd9db83593e"},
+    {file = "boto3-1.38.39-py3-none-any.whl", hash = "sha256:6472f7f3f13783e9c9c5d0042173b32a0e7000073d0a57a725d38cd157ce3332"},
+    {file = "boto3-1.38.39.tar.gz", hash = "sha256:22cca12cfe1b24670de53e3b8f4c69bdf34a2bd3e3363f72393b6b03bb0d78bc"},
 ]
 
 [package.dependencies]
-botocore = ">=1.38.36,<1.39.0"
+botocore = ">=1.38.39,<1.39.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.13.0,<0.14.0"
 
@@ -203,14 +203,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.38.36"
+version = "1.38.39"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "botocore-1.38.36-py3-none-any.whl", hash = "sha256:b6a50b853f6d23af9edfed89a59800c6bc1687a947cdd3492879f7d64e002d30"},
-    {file = "botocore-1.38.36.tar.gz", hash = "sha256:4a1ced1a4218bdff0ed5b46abb54570d473154ddefafa5d121a8d96e4b76ebc1"},
+    {file = "botocore-1.38.39-py3-none-any.whl", hash = "sha256:ee3aa03af1dabed4f3710cd64f6d9d488281eee720710bf1cf9f2b2fd30025ae"},
+    {file = "botocore-1.38.39.tar.gz", hash = "sha256:2305f688e9328af473a504197584112f228513e06412038d83205ce8d1456f40"},
 ]
 
 [package.dependencies]
@@ -1339,14 +1339,14 @@ files = [
 
 [[package]]
 name = "moto"
-version = "5.1.5"
+version = "5.1.6"
 description = "A library that allows you to easily mock out tests based on AWS infrastructure"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "moto-5.1.5-py3-none-any.whl", hash = "sha256:866ae85eb5efe11a78f991127531878fd7f49177eb4a6680f47060430eb8932d"},
-    {file = "moto-5.1.5.tar.gz", hash = "sha256:42b362ea9a16181e8e7b615ac212c294b882f020e9ae02f01230f167926df84e"},
+    {file = "moto-5.1.6-py3-none-any.whl", hash = "sha256:e4a3092bc8fe9139caa77cd34cdcbad804de4d9671e2270ea3b4d53f5c645047"},
+    {file = "moto-5.1.6.tar.gz", hash = "sha256:baf7afa9d4a92f07277b29cf466d0738f25db2ed2ee12afcb1dc3f2c540beebd"},
 ]
 
 [package.dependencies]
@@ -1421,14 +1421,14 @@ test-extras = ["pytest-mpl", "pytest-randomly"]
 
 [[package]]
 name = "oauthlib"
-version = "3.2.2"
+version = "3.3.0"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca"},
-    {file = "oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"},
+    {file = "oauthlib-3.3.0-py3-none-any.whl", hash = "sha256:a2b3a0a2a4ec2feb4b9110f56674a39b2cc2f23e14713f4ed20441dfba14e934"},
+    {file = "oauthlib-3.3.0.tar.gz", hash = "sha256:4e707cf88d7dfc22a8cce22ca736a2eef9967c1dd3845efc0703fc922353eeb2"},
 ]
 
 [package.extras]
@@ -1438,14 +1438,14 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "openai"
-version = "1.86.0"
+version = "1.88.0"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "openai-1.86.0-py3-none-any.whl", hash = "sha256:c8889c39410621fe955c230cc4c21bfe36ec887f4e60a957de05f507d7e1f349"},
-    {file = "openai-1.86.0.tar.gz", hash = "sha256:c64d5b788359a8fdf69bd605ae804ce41c1ce2e78b8dd93e2542e0ee267f1e4b"},
+    {file = "openai-1.88.0-py3-none-any.whl", hash = "sha256:7edd7826b3b83f5846562a6f310f040c79576278bf8e3687b30ba05bb5dff978"},
+    {file = "openai-1.88.0.tar.gz", hash = "sha256:122d35e42998255cf1fc84560f6ee49a844e65c054cd05d3e42fda506b832bb1"},
 ]
 
 [package.dependencies]
@@ -1901,14 +1901,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.0"
+version = "8.4.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e"},
-    {file = "pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6"},
+    {file = "pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7"},
+    {file = "pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c"},
 ]
 
 [package.dependencies]
@@ -2542,14 +2542,14 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "urllib3"
-version = "2.4.0"
+version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
-    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
+    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
+    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
 ]
 
 [package.extras]
@@ -2707,4 +2707,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "3506618cd960e800657128401b45a7a39d8d7e868320471d7b0dc578dbca6393"
+content-hash = "769fbebe575716c592c8afc0339c6ed7aa2eabea36414fd39b50e53c6d2cf787"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ setuptools = "^78.1"
 pydantic-settings = "^2.3.4"
 packaging = "^24.1"
 openai = "^1.3"
+urllib3 = ">=2.5"
 
 [tool.poetry.scripts]
 worker = 'tfworker.cli:cli'

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -349,10 +349,6 @@ class TestCLIOptionsTerraform:
         cli_options = c.CLIOptionsTerraform(target=["module.resource"])
         assert cli_options.target == ["module.resource"]
 
-    def test_validate_target_with_no_plan(self):
-        with pytest.raises(ValueError):
-            c.CLIOptionsTerraform(target=["module.resource"], plan=False)
-
     def test_validate_target_csv(self):
         cli_options = c.CLIOptionsTerraform(target="module1.resource,module2.resource")
         assert sorted(cli_options.target) == sorted(

--- a/tests/util/test_util_hooks.py
+++ b/tests/util/test_util_hooks.py
@@ -287,10 +287,10 @@ class TestHelperFunctions:
         )
         mock_pipe_exec.assert_called_once_with(
             "hook_script pre plan",
-            stdin=None,
             cwd="working_dir/hooks",
             env={},
             stream_output=False,
+            stdin=None,
         )
         captured = capsys.readouterr()
         captured_lines = captured.out.splitlines()

--- a/tfworker/cli_options.py
+++ b/tfworker/cli_options.py
@@ -399,32 +399,6 @@ class CLIOptionsTerraform(FreezableBaseModel):
             raise ValidationError.from_exception_data("apply_and_destroy", errors)
         return values
 
-    @model_validator(mode="before")
-    @classmethod
-    def validate_target_requires_plan(cls, values):
-        errors = []
-        if values.get("target") and not values.get("plan", True):
-            for t in values.get("target", []):
-                errors.append(
-                    InitErrorDetails(
-                        loc=("--target", "--target"),
-                        input=t,
-                        ctx={"error": "--target cannot be used with --no-plan"},
-                        type="value_error",
-                    )
-                )
-            errors.append(
-                InitErrorDetails(
-                    loc=("--plan", "--plan"),
-                    input=False,
-                    ctx={"error": "--target cannot be used with --no-plan"},
-                    type="value_error",
-                )
-            )
-        if errors:
-            raise ValidationError.from_exception_data("target_requires_plan", errors)
-        return values
-
     @field_validator("terraform_bin")
     @classmethod
     def validate_terraform_bin(cls, fpath: Union[str, None]) -> Union[str, None]:

--- a/tfworker/definitions/collection.py
+++ b/tfworker/definitions/collection.py
@@ -51,14 +51,11 @@ class DefinitionsCollection(Mapping):
                 except ValidationError as e:
                     handle_config_error(e)
 
-                if config.always_apply or config.always_include:
-                    log.trace(
-                        f"definition {definition} is set to always_[apply|include]"
-                    )
-                elif len(limiter) > 0 and definition not in limiter:
-                    log.trace(f"definition {definition} not in limiter, skipping")
-                    continue
-
+                if len(limiter) > 0 and definition not in limiter:
+                    if not config.always_include:
+                        log.trace(f"definition {definition} not in limiter, skipping")
+                        continue
+                    log.trace(f"definition {definition} has always_include")
                 log.trace(f"adding definition {definition} to definitions")
                 self._definitions[definition] = config
             self._initialized = True

--- a/tfworker/definitions/model.py
+++ b/tfworker/definitions/model.py
@@ -59,6 +59,8 @@ class Definition(BaseModel):
         {},
         description="Variables which are used to generate local references to remote state vars.",
     )
+    squelch_plan_output: bool = False
+    squelch_apply_output: bool = False
     template_vars: Optional[Dict[str, str | bool | list | dict]] = Field(
         {}, description="Variables which are suppled to any jinja templates."
     )


### PR DESCRIPTION
- always_apply was not actually triggering apply correctly
- when always_apply is set, force the terraform exit_code to 2, triggering plan activities
- update the poetry version ; and update libraries to fix security warnings
- relax the validation of the --target option, warn when used with apply but do not fail validation
- always_apply should not imply always_include
- added options for squelching specific definition output (allows per definition handling, same results as toggling --stream-output option)