### PR TITLE
INF-6294: Address two minor issues with plan files during large single phase runs

### DIFF
--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -148,6 +148,9 @@ class TerraformCommand(BaseCommand):
                 f"needs_apply value: {self.app_state.definitions[name].needs_apply}"
             )
             if self.app_state.definitions[name].needs_apply:
+                if not self._app_state.definitions[name].plan_file.exists():
+                    log.info(f"plan file does not exist for definition: {name}; skipping apply")
+                    continue
                 log.info(f"running apply for definition: {name}")
                 self._exec_terraform_action(name=name, action=action)
 

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -221,6 +221,9 @@ class TerraformCommand(BaseCommand):
             result,
         )
 
+        if action == TerraformAction.APPLY:
+            definition.plan_file.unlink(missing_ok=True)
+
     def _exec_terraform_pre_plan(self, name: str) -> None:
         """
         Execute terraform pre plan with hooks and handlers for the given definition


### PR DESCRIPTION
It is possible for a definition to reach needs_apply based on configured options, when a valid plan file does not exist. Currently it will still attempt to execute terraform, which will fail with an error code when there is no plan file and halt the execution of the rest of the deployment. This changes the behavior by checking if a plan file exists. 

Secondarily, plan files were retained after they were applied (unless using S3 remote storage for plan files in conjunction with a run-id). This causes future runs to not plan, the internal deploy tooling we use covered this up because it removes plan files prior to running a plan, but a consumed plan will never be valid as the lineage will change, so there is no value in keeping a previously applied plan file. This does not affect or change behavior of the console output log for prior plans. 