### PR TITLE
INF-6294: Add configurable parallel processing and fix remote variable inheritance

### DIFF
--- a/tests/commands/test_config.py
+++ b/tests/commands/test_config.py
@@ -29,6 +29,22 @@ class TestLoadConfig:
         assert loaded.definitions["mod"]["path"] == "/new"
         assert "extra" in loaded.definitions
 
+    def test_parallel_options_defaults(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("""terraform:\n  definitions:\n    a:\n      path: /a\n""")
+        loaded = c.load_config(str(cfg), {"deployment": "d"})
+        assert loaded.parallel_options.max_preparation_workers == 8
+        assert loaded.parallel_options.max_init_workers == 4
+
+    def test_parallel_options_custom(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            """terraform:\n  parallel_options:\n    max_preparation_workers: 2\n    max_init_workers: 1\n  definitions:\n    a:\n      path: /a\n"""
+        )
+        loaded = c.load_config(str(cfg), {"deployment": "d"})
+        assert loaded.parallel_options.max_preparation_workers == 2
+        assert loaded.parallel_options.max_init_workers == 1
+
 
 class TestProcessTemplate:
     def test_template_vars(self, tmp_path):

--- a/tfworker/definitions/prepare.py
+++ b/tfworker/definitions/prepare.py
@@ -185,7 +185,12 @@ class DefinitionPrepare:
             remotes = self._app_state.backend.remotes
         else:
             remotes = list(
-                map(lambda x: x.split(".")[0], definition.remote_vars.values())
+                map(
+                    lambda x: x.split(".")[0],
+                    definition.get_remote_vars(
+                        global_vars=self._app_state.loaded_config.global_vars.remote_vars
+                    ).values(),
+                )
             )
             log.trace(f"using remotes {remotes} for definition {name}")
         return remotes


### PR DESCRIPTION
## Summary

- Fix critical timing issue where global remote variables weren't inherited when creating remote data sources
- Add configurable parallelization options to prevent API rate limiting and accommodate slow connections
- Implement clean output capture for parallel terraform init operations to eliminate garbled output

## Thread Safety Analysis
1. Definitions are frozen in tfworker/commands/base.py:68 via self._app_state.freeze() which calls self.definitions.freeze()
2. But definitions have mutable runtime fields that are exempt from freezing:
 - ready: bool = False
 - needs_apply: bool = False
 - plan_file: Optional[str] = None
3. The parallel init phase is read-only: _terraform_init_single_parallel() only:
- Reads definition.plan_file (line 152)
- Calls definition.get_target_path() (line 154)
- Never modifies any definition properties
4. Definition modifications happen later in separate phases:
- plan_file is set during plan phase in tfworker/definitions/plan.py:25
- needs_apply is set during plan phase in tfworker/commands/terraform.py:200,236
- These happen after parallel init completes
5. No race conditions: Each definition is processed independently in separate threads, and they only read immutable configuration data during init.

The parallel processing is completely safe with frozen models since the init phase is purely read-only for definition properties.

## Changes

### Bug Fixes
- **Remote variable inheritance**: Fixed `_get_remotes()` to use `get_remote_vars()` instead of raw `remote_vars`, ensuring global remote variables are properly inherited when creating Terraform remote data sources
- **Output handling**: Replaced streaming output during parallel terraform init with captured output to prevent interleaved/garbled console output

  ### New Features
  - **Configurable parallelization**: Added `parallel_options` config section allowing users to control `max_preparation_workers`
  (default: 8) and `max_init_workers` (default: 4)
  - **Clean parallel logging**: Added per-definition output tagging with `[definition_name]` prefixes for easy identification

### Testing
- Added comprehensive test coverage for remote variable inheritance in data source creation
- Added tests for configurable parallelization options (defaults and custom values)
- Added tests for parallel output capture functionality
- Updated existing tests to accommodate new parallel execution paths

## Configuration Example
```yaml
  terraform:
    parallel_options:
      max_preparation_workers: 4  # Reduce for slow connections
      max_init_workers: 2         # Reduce for API rate limits
```

 ## Test Plan
- All existing tests pass (460/460)
- New tests verify global remote variable inheritance works correctly
- New tests verify configurable parallelization works
- New tests verify clean output capture during parallel operations