### PR TITLE
INF-6294: Fix parallel terraform init implementation to avoid functionality loss

### DIFF
--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -330,27 +330,11 @@ class TestTerraformCommandMethods:
         for i in range(2, 5):
             cmd.app_state.definitions[f"def{i}"] = cmd.app_state.definitions["def"]
         prepare_mock = mocker.patch.object(cmd, "_prepare_definition")
-        init_mock = mocker.patch.object(cmd, "_terraform_init_single_parallel")
+        init_mock = mocker.patch.object(cmd, "_terraform_init_single")
         cmd.terraform_init()
         assert prepare_mock.call_count == 4
         assert init_mock.call_count == 4
 
-    def test_terraform_init_single_parallel_captured_output(self, tmp_path, mocker):
-        cmd = make_command(tmp_path)
-        mock_pipe_exec = mocker.patch(
-            "tfworker.commands.terraform.pipe_exec",
-            return_value=(0, b"Terraform initialized successfully!", b""),
-        )
-        mock_log_info = mocker.patch("tfworker.commands.terraform.log.info")
-        mock_log_debug = mocker.patch("tfworker.commands.terraform.log.debug")
-
-        cmd._terraform_init_single_parallel("def")
-
-        mock_pipe_exec.assert_called_once()
-        args, kwargs = mock_pipe_exec.call_args
-        assert kwargs["stream_output"] is False
-        mock_log_info.assert_called_with("Terraform init completed for definition: def")
-        mock_log_debug.assert_called_with("[def] Terraform initialized successfully!")
 
 
 class TestTerraformResult:


### PR DESCRIPTION
### Problem

The parallel terraform init implementation introduced a bug that changed the behavior and caused loss of functionality. The issue was in _terraform_init_single_parallel() method which duplicated logic from _exec_terraform_action() and _run(), bypassing critical functionality including:
- Pre/post hooks execution
- Handlers execution
- Configuration options like squelch_apply_output
- Proper error handling and output management

### Solution

Instead of maintaining duplicate methods, this PR simplifies the approach by using a stream output override pattern:

1. Eliminated duplicate code - Removed _terraform_init_single_parallel() entirely
2. Unified execution path - Both sequential and parallel execution now use the same _exec_terraform_action() method
3. Added stream output override - Enhanced TerraformCommandConfig with temporary override mechanism:
- force_no_stream_output() - Forces stream_output to False during parallel execution
- clear_stream_output_override() - Restores normal behavior
- Works around frozen model constraints by overriding property access instead of modifying frozen objects
4. Enhanced error handling - Modified _exec_terraform_action() to return TerraformResult and show captured output at error level when streaming is disabled
5. Added helper methods for clean separation of concerns:
- _handle_parallel_init_results() - Manages parallel execution results
- _log_terraform_result() - Handles output logging with definition name prefixes
6. Improved file organization - Moved private methods after public methods following Python conventions

### Key Benefits

  - No functionality loss - All hooks, handlers, and configuration options preserved
  - Single code path - Eliminates ~40 lines of duplicated logic
  - Proper output handling - Shows terraform output appropriately based on user's original stream_output setting
  - Works with frozen models - Override mechanism respects immutable configuration objects
  - Better error visibility - Failed parallel executions show captured output at error level

### Testing
- All existing tests pass (30/30)
- Updated tests to reflect the simplified implementation
- Removed obsolete test for the duplicate method
