### PR TITLE
INF-6229: Optimize terraform init by skipping when no plans available…

### DIFF
--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -337,7 +337,7 @@ class TestTerraformCommandMethods:
         assert prepare_mock.call_count == 4
         assert init_mock.call_count == 4
 
-    def test_terraform_init_proceeds_when_no_plan_and_handler_has_plan(
+    def test_terraform_init_proceeds_no_local_plan_and_handler_has_plan(
         self, tmp_path, mocker
     ):
         """Test that init proceeds when --no-plan is set and handler has plan available"""
@@ -364,7 +364,7 @@ class TestTerraformCommandMethods:
         assert init_mock.call_count == 1
         assert cmd.app_state.definitions["def"].needs_apply is True
 
-    def test_terraform_init_proceeds_when_no_plan_and_local_plan_exists(
+    def test_terraform_init_proceeds_with_local_plan_and_no_handler_plan(
         self, tmp_path, mocker
     ):
         """Test that init proceeds when --no-plan is set and local plan file exists"""
@@ -390,7 +390,7 @@ class TestTerraformCommandMethods:
         assert init_mock.call_count == 1
         assert cmd.app_state.definitions["def"].needs_apply is True
 
-    def test_terraform_init_skipped_when_no_plan_and_no_plans_available(
+    def test_terraform_init_skipped_no_local_plan_and_no_handler_plan(
         self, tmp_path, mocker
     ):
         """Test that init is skipped when --no-plan is set and no plans are available"""
@@ -449,7 +449,9 @@ class TestGetDefinitionsNeedingInit:
         result = cmd._get_definitions_needing_init()
         assert result == ["def1", "def2"]
 
-    def test_init_needed_when_no_plan_and_plans_available(self, tmp_path, mocker):
+    def test_no_plan_with_local_no_local_plan_and_handler_has_plans(
+        self, tmp_path, mocker
+    ):
         """Test that init is needed when --no-plan is set and plans are available"""
         cmd = make_command(tmp_path, plan=False, plan_file_path=None)
         mock_def = mock.Mock()
@@ -468,7 +470,7 @@ class TestGetDefinitionsNeedingInit:
         assert result == ["def1"]
         assert mock_def.needs_apply is True
 
-    def test_init_needed_when_no_plan_and_local_plan_exists(self, tmp_path, mocker):
+    def test_no_plan_with_local_plan_and_no_handler_plan(self, tmp_path, mocker):
         """Test that init is needed when --no-plan is set and local plan exists"""
         cmd = make_command(tmp_path, plan=False, plan_file_path=None)
         mock_def = mock.Mock()
@@ -487,7 +489,7 @@ class TestGetDefinitionsNeedingInit:
         assert result == ["def1"]
         assert mock_def.needs_apply is True
 
-    def test_init_skipped_when_no_plan_and_no_plans_available(self, tmp_path, mocker):
+    def test_no_plan_with_no_local_plan_and_no_handler_plan(self, tmp_path, mocker):
         """Test that init is skipped when --no-plan is set and no plans are available"""
         cmd = make_command(tmp_path, plan=False, plan_file_path=None)
         mock_def = mock.Mock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from moto import mock_aws
 
 from tfworker.app_state import AppState
 from tfworker.authenticators import AuthenticatorsCollection
+from tfworker.backends import Backends
 from tfworker.cli_options import CLIOptionsClean, CLIOptionsRoot, CLIOptionsTerraform
 from tfworker.custom_types.config_file import ConfigFile, GlobalVars
 
@@ -46,6 +47,7 @@ def mock_cli_options_root():
     mock_root.region = "us-east-1"
     mock_root.backend_region = "us-east-1"
     mock_root.backend_bucket = "test-bucket"
+    mock_root.backend = Backends.S3
     mock_root.backend_plans = False
     mock_root.backend_prefix = "prefix"
     mock_root.create_backend_bucket = True
@@ -61,6 +63,7 @@ def mock_cli_options_root_backend_west():
     mock_root.region = "us-east-1"
     mock_root.backend_region = "us-west-2"
     mock_root.backend_bucket = "west-test-bucket"
+    mock_root.backend = Backends.S3
     mock_root.backend_plans = False
     mock_root.backend_prefix = "prefix"
     mock_root.create_backend_bucket = True

--- a/tests/handlers/test_handlers_collection_order.py
+++ b/tests/handlers/test_handlers_collection_order.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tfworker.custom_types import TerraformAction, TerraformStage
+from tfworker.exceptions import HandlerError
 from tfworker.handlers.base import BaseHandler
 from tfworker.handlers.collection import HandlersCollection
 
@@ -71,3 +72,108 @@ def test_missing_dependency_ignored():
     )
     h.exec_handlers(TerraformAction.PLAN, TerraformStage.POST, "dep", DummyDef(), ".")
     assert ORDER == ["a", "d"]
+
+
+class HandlerWithPlan(DummyHandler):
+    tag = "with_plan"
+
+    def has_plan(self, definition):
+        return True
+
+
+class HandlerWithoutPlan(DummyHandler):
+    tag = "without_plan"
+
+    def has_plan(self, definition):
+        return False
+
+
+class TestCheckPlanConflicts:
+    def test_no_conflicts_with_no_handlers_having_plans(self):
+        h = HandlersCollection(
+            {
+                "a": HandlerWithoutPlan(),
+                "b": HandlerWithoutPlan(),
+            }
+        )
+        # Should not raise
+        h.check_plan_conflicts(DummyDef())
+
+    def test_no_conflicts_with_one_handler_having_plan(self):
+        h = HandlersCollection(
+            {
+                "a": HandlerWithPlan(),
+                "b": HandlerWithoutPlan(),
+            }
+        )
+        # Should not raise
+        h.check_plan_conflicts(DummyDef())
+
+    def test_conflict_with_multiple_handlers_having_plans(self):
+        h = HandlersCollection(
+            {
+                "a": HandlerWithPlan(),
+                "b": HandlerWithPlan(),
+            }
+        )
+        with pytest.raises(
+            HandlerError, match="Multiple handlers claim to have a plan"
+        ):
+            h.check_plan_conflicts(DummyDef())
+
+    def test_not_ready_handler_ignored_in_conflict_check(self):
+        handler_not_ready = HandlerWithPlan()
+        handler_not_ready._ready = False
+
+        h = HandlersCollection(
+            {
+                "a": HandlerWithPlan(),
+                "b": handler_not_ready,
+            }
+        )
+        # Should not raise since handler b is not ready
+        h.check_plan_conflicts(DummyDef())
+
+
+class TestHasAvailablePlan:
+    def test_returns_false_when_no_handlers_have_plans(self):
+        h = HandlersCollection(
+            {
+                "a": HandlerWithoutPlan(),
+                "b": HandlerWithoutPlan(),
+            }
+        )
+        assert h.has_available_plan(DummyDef()) is False
+
+    def test_returns_true_when_handler_has_plan(self):
+        h = HandlersCollection(
+            {
+                "a": HandlerWithPlan(),
+                "b": HandlerWithoutPlan(),
+            }
+        )
+        assert h.has_available_plan(DummyDef()) is True
+
+    def test_raises_on_conflict(self):
+        h = HandlersCollection(
+            {
+                "a": HandlerWithPlan(),
+                "b": HandlerWithPlan(),
+            }
+        )
+        with pytest.raises(
+            HandlerError, match="Multiple handlers claim to have a plan"
+        ):
+            h.has_available_plan(DummyDef())
+
+    def test_ignores_not_ready_handlers(self):
+        handler_not_ready = HandlerWithPlan()
+        handler_not_ready._ready = False
+
+        h = HandlersCollection(
+            {
+                "a": HandlerWithoutPlan(),
+                "b": handler_not_ready,
+            }
+        )
+        assert h.has_available_plan(DummyDef()) is False

--- a/tfworker/definitions/plan.py
+++ b/tfworker/definitions/plan.py
@@ -74,4 +74,8 @@ class DefinitionPlan:
             plan_file.unlink()
             return True, "empty plan file"
 
+        # Check if any handler has a plan available
+        if self._app_state.handlers.has_available_plan(definition):
+            return False, "plan available from handler"
+
         return True, "no plan file"

--- a/tfworker/handlers/base.py
+++ b/tfworker/handlers/base.py
@@ -37,6 +37,17 @@ class BaseHandler(metaclass=ABCMeta):
         except AttributeError:
             return False
 
+    def has_plan(self, definition: "Definition") -> bool:  # pragma: no cover
+        """
+        has_plan is called to determine if a handler can provide an existing plan
+        for the given definition. This allows handlers to indicate they have a plan
+        available without executing the full plan workflow.
+
+        Returns:
+            bool: True if handler has a plan available for this definition
+        """
+        return False
+
     @abstractmethod
     def execute(
         self,


### PR DESCRIPTION
## Summary
Optimize terraform applies by skipping initialization when no plans are available in apply-only mode (`--no-plan`).

## Changes
- **Performance optimization**: Skip time-consuming `terraform init` when no plans exist and `--no-plan` is specified
- **New handler interface**: Add `has_plan()` method to check remote plan availability (S3Handler implementation included)
- **Conflict detection**: Prevent multiple handlers from claiming the same plan
- **Comprehensive testing**: Full test coverage for all optimization scenarios

## Workflow Impact
- **Before**: `--no-plan` mode always ran init, even when no plans existed to apply
- **After**: `--no-plan` mode skips init when no plans available (significant time savings)
- **When plans exist**: Init still runs to prepare workspace for apply

Reduces deployment time in apply-only workflows when no infrastructure changes are pending.
