### PR TITLE
INF-6330: Fix bug with init only

### DIFF
--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -507,6 +507,14 @@ class TestGetDefinitionsNeedingInit:
         result = cmd._get_definitions_needing_init()
         assert result == []
 
+    def test_all_definitions_when_not_apply_mode(self, tmp_path, mocker):
+        """Test that all definitions are returned when NOT in apply mode"""
+        cmd = make_command(tmp_path, plan=False, apply=False, plan_file_path=None)
+        cmd.app_state.definitions = {"def1": mock.Mock(), "def2": mock.Mock()}
+
+        result = cmd._get_definitions_needing_init()
+        assert result == ["def1", "def2"]
+
 
 class TestTerraformResult:
     def test_logging_and_file(self, tmp_path, mocker):

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -84,6 +84,10 @@ class TerraformCommand(BaseCommand):
         if self.app_state.terraform_options.plan:
             return all_definition_names
 
+        # If NOT in apply mode, all definitions need init
+        if not self.app_state.terraform_options.apply:
+            return all_definition_names
+
         # In apply-only mode, skip init for definitions that have NO plans
         # (since apply will be skipped anyway without a plan)
         from tfworker.definitions.plan import DefinitionPlan


### PR DESCRIPTION
Sometimes we want to init everything, and in this case --no-plan and --no-apply are both used. This is helpful when gathering terraform outputs, or debugging the rendered definition. This adds a check that if it is run in this way, all definitions are returned for init. 