### PR TITLE
INF-6913: Improve subprocess log output

### DIFF
--- a/tests/commands/test_terraform.py
+++ b/tests/commands/test_terraform.py
@@ -221,9 +221,12 @@ class TestTerraformCommandMethods:
 
         mocker.patch.object(TerraformCommandConfig, "get_params", return_value="params")
         pe = mocker.patch(
-            "tfworker.commands.terraform.pipe_exec", return_value=(0, b"stdout", b"stderr")
+            "tfworker.commands.terraform.pipe_exec",
+            return_value=(0, b"stdout", b"stderr"),
         )
-        aggregate = mocker.patch("tfworker.commands.terraform.log.log_subprocess_result")
+        aggregate = mocker.patch(
+            "tfworker.commands.terraform.log.log_subprocess_result"
+        )
 
         cmd._run("def", TerraformAction.APPLY)
 
@@ -238,6 +241,7 @@ class TestTerraformCommandMethods:
                 "definition": "def",
                 "terraform_action": "apply",
             },
+            message="terraform apply output for def",
         )
         log.log_format = old_format
 
@@ -251,9 +255,12 @@ class TestTerraformCommandMethods:
 
         mocker.patch.object(TerraformCommandConfig, "get_params", return_value="params")
         mocker.patch(
-            "tfworker.commands.terraform.pipe_exec", return_value=(2, b"stdout", b"stderr")
+            "tfworker.commands.terraform.pipe_exec",
+            return_value=(2, b"stdout", b"stderr"),
         )
-        aggregate = mocker.patch("tfworker.commands.terraform.log.log_subprocess_result")
+        aggregate = mocker.patch(
+            "tfworker.commands.terraform.log.log_subprocess_result"
+        )
 
         cmd._run("def", TerraformAction.PLAN)
 
@@ -267,6 +274,7 @@ class TestTerraformCommandMethods:
                 "definition": "def",
                 "terraform_action": "plan",
             },
+            message="terraform plan output for def",
         )
         log.log_format = old_format
 
@@ -280,9 +288,12 @@ class TestTerraformCommandMethods:
 
         mocker.patch.object(TerraformCommandConfig, "get_params", return_value="params")
         mocker.patch(
-            "tfworker.commands.terraform.pipe_exec", return_value=(1, b"stdout", b"stderr")
+            "tfworker.commands.terraform.pipe_exec",
+            return_value=(1, b"stdout", b"stderr"),
         )
-        aggregate = mocker.patch("tfworker.commands.terraform.log.log_subprocess_result")
+        aggregate = mocker.patch(
+            "tfworker.commands.terraform.log.log_subprocess_result"
+        )
 
         cmd._run("def", TerraformAction.PLAN)
 
@@ -296,6 +307,7 @@ class TestTerraformCommandMethods:
                 "definition": "def",
                 "terraform_action": "plan",
             },
+            message="terraform plan output for def",
         )
         log.log_format = old_format
 
@@ -309,9 +321,12 @@ class TestTerraformCommandMethods:
 
         mocker.patch.object(TerraformCommandConfig, "get_params", return_value="params")
         mocker.patch(
-            "tfworker.commands.terraform.pipe_exec", return_value=(2, b"stdout", b"stderr")
+            "tfworker.commands.terraform.pipe_exec",
+            return_value=(2, b"stdout", b"stderr"),
         )
-        aggregate = mocker.patch("tfworker.commands.terraform.log.log_subprocess_result")
+        aggregate = mocker.patch(
+            "tfworker.commands.terraform.log.log_subprocess_result"
+        )
 
         cmd._run("def", TerraformAction.APPLY)
 
@@ -325,6 +340,7 @@ class TestTerraformCommandMethods:
                 "definition": "def",
                 "terraform_action": "apply",
             },
+            message="terraform apply output for def",
         )
         log.log_format = old_format
 

--- a/tests/util/test_util_log.py
+++ b/tests/util/test_util_log.py
@@ -396,7 +396,7 @@ def test_log_subprocess_result_json(mock_secho):
     mock_secho.assert_called_once()
     args, kwargs = mock_secho.call_args
     payload = json.loads(args[0])
-    assert payload["message"] == "subprocess completed"
+    assert payload["message"] == "terraform init completed"
     assert payload["command"] == "terraform init"
     assert payload["definition"] == "example"
     assert payload["stdout"] == "stdout text"

--- a/tfworker/commands/terraform.py
+++ b/tfworker/commands/terraform.py
@@ -616,6 +616,7 @@ class TerraformCommand(BaseCommand):
                     "definition": definition_name,
                     "terraform_action": action.value,
                 },
+                message=f"terraform {terraform_command} output for {definition_name}",
             )
 
         log.debug(f"exit code: {result.exit_code}")

--- a/tfworker/definitions/prepare.py
+++ b/tfworker/definitions/prepare.py
@@ -182,6 +182,7 @@ class DefinitionPrepare:
                 stderr=result.stderr,
                 level=log.LogLevel.ERROR if result.exit_code else log.LogLevel.INFO,
                 extra={"definition": name},
+                message=f"terraform get output for {name}",
             )
         elif not stream_output:
             log.debug(f"terraform get result: {result.stdout}")

--- a/tfworker/util/hooks.py
+++ b/tfworker/util/hooks.py
@@ -571,7 +571,9 @@ def _execute_hook_script(
             extra={
                 "hook_script": hook_script,
                 "hook_phase": phase.value if hasattr(phase, "value") else str(phase),
-                "hook_action": command.value if hasattr(command, "value") else str(command),
+                "hook_action": (
+                    command.value if hasattr(command, "value") else str(command)
+                ),
             },
         )
 

--- a/tfworker/util/log.py
+++ b/tfworker/util/log.py
@@ -41,9 +41,10 @@ def log_subprocess_result(
     level: LogLevel = LogLevel.INFO,
     extra: Dict[str, Any] | None = None,
     redact: bool = False,
+    message: str | None = None,
 ) -> None:
     payload: Dict[str, Any] = {
-        "message": "subprocess completed",
+        "message": message or f"{command} completed",
         "source": "subprocess",
         "command": command,
         "exit_code": exit_code,
@@ -61,9 +62,7 @@ def _normalize_message(msg: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
     return {"message": str(msg)}
 
 
-def _format_json_message(
-    msg: Union[str, Dict[str, Any]], level: LogLevel
-) -> str:
+def _format_json_message(msg: Union[str, Dict[str, Any]], level: LogLevel) -> str:
     payload = {
         "timestamp": datetime.now(UTC).isoformat(),
         "level": level.name,


### PR DESCRIPTION
This small update improves the json logging output. Log aggregation systems such as datadog will use the "message" feild, and then include the other fields when digging deeper.  Prior the message for all subprocesses was "subprocess complete". This changes the default to be "<command> complete" where command is the first item to the exec call. A caller can set "message", and in this case everywhere terraform is called, it sets the message "terraform <action> output for <definition>" so you can easily see init, plan, and apply output wrapped up in a tidy log envelope.