### PR TITLE
INF-7036: support nested remote_var structures and bracket notation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: poetry run isort --check tfworker tests
 
       - name: Lint (flake8)
-        run: poetry run flake8 --ignore E501,W503 tfworker tests
+        run: poetry run flake8 --ignore E203,E501,W503 tfworker tests
 
   test:
     name: Test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ init-dev:
 default: lint test
 
 lint: init-dev
-	poetry run flake8 --ignore E501,W503 tfworker tests
+	poetry run flake8 --ignore E203,E501,W503 tfworker tests
 
 format: init-dev
 	poetry run black tfworker tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,14 +26,14 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.14.0"
+version = "4.14.1"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9"},
-    {file = "anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89"},
+    {file = "anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72"},
+    {file = "anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e"},
 ]
 
 [package.dependencies]
@@ -186,34 +186,34 @@ uvloop = ["uvloop (>=0.15.2) ; sys_platform != \"win32\"", "winloop (>=0.5.0) ; 
 
 [[package]]
 name = "boto3"
-version = "1.43.30"
+version = "1.43.36"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "boto3-1.43.30-py3-none-any.whl", hash = "sha256:89e982463d94773136ccf69be77cccd54ff1ce351a6aadd1d3437fcb693681b5"},
-    {file = "boto3-1.43.30.tar.gz", hash = "sha256:6b1ee360f363a457f67a8f5702f522043d8a32d67a97c362ad12075d8b5b531e"},
+    {file = "boto3-1.43.36-py3-none-any.whl", hash = "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f"},
+    {file = "boto3-1.43.36.tar.gz", hash = "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28"},
 ]
 
 [package.dependencies]
-botocore = ">=1.43.30,<1.44.0"
+botocore = ">=1.43.36,<1.44.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.18.0,<0.19.0"
+s3transfer = ">=0.19.0,<0.20.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.43.30"
+version = "1.43.36"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "botocore-1.43.30-py3-none-any.whl", hash = "sha256:26b1dded84d89b396180916f56900bd2ab1c0d545a66d1d2c3eeb40f772935b2"},
-    {file = "botocore-1.43.30.tar.gz", hash = "sha256:19ed560cb35ae43bf010d37da429a553c07063bf7efea0f2cb53be8a78d3e3d5"},
+    {file = "botocore-1.43.36-py3-none-any.whl", hash = "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d"},
+    {file = "botocore-1.43.36.tar.gz", hash = "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205"},
 ]
 
 [package.dependencies]
@@ -226,14 +226,14 @@ crt = ["awscrt (==0.32.2)"]
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897"},
-    {file = "certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d"},
+    {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
+    {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
 ]
 
 [[package]]
@@ -475,14 +475,14 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.4.1"
+version = "8.4.2"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2"},
-    {file = "click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"},
+    {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
+    {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
 ]
 
 [package.dependencies]
@@ -503,118 +503,103 @@ markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"
 
 [[package]]
 name = "coverage"
-version = "7.14.1"
+version = "7.14.3"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "coverage-7.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3e3680291c4a1d0dadfa84a2c459576a4af5133abb617905714339a0c73138cf"},
-    {file = "coverage-7.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5274669f37f2343635a347b91a60777621341ab3378e9c6ac9335eee704bddf"},
-    {file = "coverage-7.14.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cfe5a5fec635799ef33428f1e5e61bafa45a92a96190ba731561ba558ccc214d"},
-    {file = "coverage-7.14.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:62a9f70b52e0b5a95cfef4a5c5641b06983cadc5e538a3feeb5c00211f523ac2"},
-    {file = "coverage-7.14.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c18ebc343e15be53049b3a2dce38fe82d58f37e20ab9094b3a39c0aa4f6bb47"},
-    {file = "coverage-7.14.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b84ffdf877644e7096aa936991efeed873f7f3df57b9cd001312b7668ab08550"},
-    {file = "coverage-7.14.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e854312c4103f2ad4c0dc023b69b77ebfd2c89db5f86c4c94dc2353f9a92167e"},
-    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c643734307300234fafa36bf2a040a7235f8f177ea1fd6ec1423aea6fb7b929f"},
-    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:84ac9499e48700399a5dd0ea7085b5091961fec52c68d66b4ec0d3cf7f4441b1"},
-    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7f02d09f70776579b926d889a4c9c235070a1f47c40458aeaca563fae5acfdb5"},
-    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ce66d8e46da2bb5ee313a745cbd2e391d319176c1f7a9451bfcd3a2fb920859b"},
-    {file = "coverage-7.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c912c259304cfb5ee584481cfb7ce1ff932b4d61e6c9140b8f19cb7b5ed82332"},
-    {file = "coverage-7.14.1-cp310-cp310-win32.whl", hash = "sha256:1238cb94638e610e972c60dac68e813f868dc7d6e982535270558443058d9d59"},
-    {file = "coverage-7.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:fc459e5d73be2d6332fcfe8dbf3d8994671fe33c700f4565988ecfa511547253"},
-    {file = "coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f"},
-    {file = "coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4"},
-    {file = "coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1"},
-    {file = "coverage-7.14.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f"},
-    {file = "coverage-7.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129"},
-    {file = "coverage-7.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860"},
-    {file = "coverage-7.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c"},
-    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7"},
-    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec"},
-    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef"},
-    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df"},
-    {file = "coverage-7.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9"},
-    {file = "coverage-7.14.1-cp311-cp311-win32.whl", hash = "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548"},
-    {file = "coverage-7.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e"},
-    {file = "coverage-7.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3"},
-    {file = "coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c"},
-    {file = "coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c"},
-    {file = "coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b"},
-    {file = "coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6"},
-    {file = "coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37"},
-    {file = "coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad"},
-    {file = "coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84"},
-    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54"},
-    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7"},
-    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9"},
-    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02"},
-    {file = "coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a"},
-    {file = "coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1"},
-    {file = "coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e"},
-    {file = "coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a"},
-    {file = "coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793"},
-    {file = "coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d"},
-    {file = "coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247"},
-    {file = "coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d"},
-    {file = "coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b"},
-    {file = "coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be"},
-    {file = "coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43"},
-    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901"},
-    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff"},
-    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4"},
-    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d"},
-    {file = "coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33"},
-    {file = "coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c"},
-    {file = "coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416"},
-    {file = "coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42"},
-    {file = "coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d"},
-    {file = "coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5"},
-    {file = "coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52"},
-    {file = "coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a"},
-    {file = "coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a"},
-    {file = "coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2"},
-    {file = "coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e"},
-    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d"},
-    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb"},
-    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d"},
-    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69"},
-    {file = "coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54"},
-    {file = "coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1"},
-    {file = "coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce"},
-    {file = "coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1"},
-    {file = "coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee"},
-    {file = "coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500"},
-    {file = "coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906"},
-    {file = "coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42"},
-    {file = "coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8"},
-    {file = "coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851"},
-    {file = "coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034"},
-    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c"},
-    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36"},
-    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5"},
-    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4"},
-    {file = "coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d"},
-    {file = "coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee"},
-    {file = "coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7"},
-    {file = "coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343"},
-    {file = "coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1"},
-    {file = "coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b"},
-    {file = "coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474"},
-    {file = "coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86"},
-    {file = "coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e"},
-    {file = "coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65"},
-    {file = "coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e"},
-    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8"},
-    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07"},
-    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de"},
-    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890"},
-    {file = "coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd"},
-    {file = "coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e"},
-    {file = "coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c"},
-    {file = "coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af"},
-    {file = "coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2"},
-    {file = "coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be"},
+    {file = "coverage-7.14.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:360bec1f58e7243e3405d3bdf7a1a8115aa9b448d54dc7cd6f7b7e0e9406b62e"},
+    {file = "coverage-7.14.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed68faa5e85de2f3e400bc3f122e5c82735a58c8bb24b9f63a2215954ba17b2d"},
+    {file = "coverage-7.14.3-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:830c1fca669c572dec37ce9c838224ee45aac5be0f6961edf871e82e49d6537c"},
+    {file = "coverage-7.14.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a64caee2193563601dbaaa55fe2dcf597debef04a2f8f1fa8a07aa4bb7ac7a1e"},
+    {file = "coverage-7.14.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0096fd7559178f0cc9cf088f2dbd2a02ef85bacaa69732c633517286b4494610"},
+    {file = "coverage-7.14.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6197e5a00183c11a8ce7c6abd18be1a9189fd8399084ffc95196f4f0db4f2137"},
+    {file = "coverage-7.14.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7dfe427045520d6abca33687dfef767b4f635015893a1816c5decb12eb72ce18"},
+    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9a3f142070eb7b82fc4085a55d887396f9c4e21250bccebe2ba22502c45b9647"},
+    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:64b2055bb6e0dc945af35cdeceb3633e6ed9273475ef3af85592410fd6803803"},
+    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:1551b4caac3e3ec9f2bfcec6bf3776e01c0edbdd2e240431a50ca1a1aac72c27"},
+    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:583d50d59142f8549470bd6390471d0fe8b8c8d69d6a0f28ac71e05380cef640"},
+    {file = "coverage-7.14.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0bb8a6bc7015efdf8a928753b25da1b9ca2d6f24ef04d2ee0688e486f32aae7"},
+    {file = "coverage-7.14.3-cp310-cp310-win32.whl", hash = "sha256:d48400185564042287dc487c1f016a3397f18ab4f4c5d5ec36edc218f7ffa35b"},
+    {file = "coverage-7.14.3-cp310-cp310-win_amd64.whl", hash = "sha256:eadea7aba74e40adee867a8c0eec17b820b061d308a4b014f7a0e118c2b0aa61"},
+    {file = "coverage-7.14.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e574801e1d643561594aa021206c46d80b257e9853087090ba97bed8b0a509d3"},
+    {file = "coverage-7.14.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f82b6bb7d75a2613e85d07cefa3a8c973d0544a8993337f6e2728e4a1e94c305"},
+    {file = "coverage-7.14.3-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a2335ea5fed26af2e831094964fa3f8fae60b45f7e37fcc2d3b615b2add3ad87"},
+    {file = "coverage-7.14.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fbb8c3a98e779013786ae01d229662aeacbc77100efbd3f2f245219ace5af700"},
+    {file = "coverage-7.14.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac082660de8f429ba0ea363595abb838998570b9a7546777c60f413ab902bbde"},
+    {file = "coverage-7.14.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac012839ff7e396030f1e94e10553a431d14e4de2ab65cb3acb72bbd5628ca2"},
+    {file = "coverage-7.14.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5952f8c1bda2a5347154450379316e6dfa4d934d62ca35f6784451e6f55074fb"},
+    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8cf0f2509acb4619e2471a1951089054dd58ebea7a912066d2ea56dd4c24ca4a"},
+    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:2e41fd3aab806770008279a93879b0924b16247e09ab537c043d08bbca53b4ab"},
+    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f0a47095963cfe054e0df178daca95aec21e680d6076da807c3add28dfe920f7"},
+    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a090cbf9521e78ffdb2fcf448b72902afe9f5923ff6a12d5c0d0120200348af9"},
+    {file = "coverage-7.14.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4d310baf69a4fbe8a098ce727e4808a34866ac718a6f759ae659cbd3221358bc"},
+    {file = "coverage-7.14.3-cp311-cp311-win32.whl", hash = "sha256:74fdd718d88fe144f4579b8747873a07ec3f04cb837d5faec5a25d9e22fa31a8"},
+    {file = "coverage-7.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:cc96aa922e21d4bc5d5ed3c915cef27dfcbc13686f47d5e378d647fbfba655a2"},
+    {file = "coverage-7.14.3-cp311-cp311-win_arm64.whl", hash = "sha256:c66f9f9d4f1e9712eb9b1de5310f881d4e2188cfcba5065e1a8490f38687f2c4"},
+    {file = "coverage-7.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3d74ff26299c4879ce3a4d826f9d3d4d556fd285fde7bbce3c0ef5a8ab1cec24"},
+    {file = "coverage-7.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:96150a9cf3468ea20f0bc5d0e21b3df8972c31480ef90fa7614b773cc6429665"},
+    {file = "coverage-7.14.3-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:27d07a46500ba23515b838dbcf52512026af04090755cf6cc64166d88c9b9a1a"},
+    {file = "coverage-7.14.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:621e13c6108234d7960aaf5762ab5c3c00f33c30c15af06dcbff0c73bf112727"},
+    {file = "coverage-7.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b60ca6d8af70473491a15a343cbabab2e8f9ea66a4376e81c7aa24876a6f977"},
+    {file = "coverage-7.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c90a7cdd5e380e1ce02f19792e2ac2fbfbf177e35a27e69fd3e873b30d895c0c"},
+    {file = "coverage-7.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d788e5fd55347eef06ca0732c77d04a264de67e8ff24631270cdff3767a60cf"},
+    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62c7f79db2851c95ef020e5d28b97afde3daf9f7febcd35b53e05638f729063f"},
+    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:90f7608aeb5d9b60b523b9fb2a4ee1973867cc4865a3f26fe6c7577073b70205"},
+    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1e3b91f9c4740aeb571ecf82e5e8d8e4ab62d34fcb5a5d4e5baa38c6f7d2857c"},
+    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c946099774a7699de03cbd0ff0a64e21aed4525eed9d959adde4afe6d15758ef"},
+    {file = "coverage-7.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:16b206e521feb8b7133a45754643dead0538489cf8b783b90cf5f4e3299625fd"},
+    {file = "coverage-7.14.3-cp312-cp312-win32.whl", hash = "sha256:ea3169c7116eb6cdf7608c6c7da9ecfcb3da40688e3a510fac2d1d2bafd6dc35"},
+    {file = "coverage-7.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:7ea52fc08f007bcc494d4bb3df3851e95843d881860ba38fe2c64dc100db5e7d"},
+    {file = "coverage-7.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:8cec0ad652ec57790970d817490105bd917d783c2f7b38d6b58a0ca312e1a336"},
+    {file = "coverage-7.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47968988b367990ae4ab17523790c38cd125e02c6bfd379b6022be2d40bdc38c"},
+    {file = "coverage-7.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ee68f5c34812780f3a7063382c0a9fcbb99985b7ddcdcaa626e4f3fb2e0783a"},
+    {file = "coverage-7.14.3-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fa9e5c6857a7e80fa22ace5cf3550ae392bbfc322f1d8dd2d2d5a8be38cec027"},
+    {file = "coverage-7.14.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:98a0859b0e98e43e1178a9402e19c8127766b14f7109a374d976e5a62c0e5c73"},
+    {file = "coverage-7.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69918344541ed9c8368566c2adc03c0e33d4550d7faa87d1b35e49b6a3286ea9"},
+    {file = "coverage-7.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b7f300ac92cd4b570724c8ffbbd0c130fee298d2447f41d5a3abf58976fae1de"},
+    {file = "coverage-7.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:11a7ec9f97ab950f4c5af62229befc7faf208fdbc0116d3902d7e306cf2c5abd"},
+    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a571bd889cd36c5922ce8e42e059f9d37d02301531d11374afa4c87a578625d5"},
+    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:de76caefc8deabb0dd1678b6a980be97d14c8d87e213ac194dbf8b09e96d63fb"},
+    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d20a15c622194234161535459affa8f7905830391c9ccfa060d495dbfe3a1c7f"},
+    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b488bd4b23397db62e7a9459129d01ff06a846582a732efd24834b24a6ada498"},
+    {file = "coverage-7.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6a3693b4153394d265f44fb855fdc80e72403024d4d6f91c4871b334d028e4e0"},
+    {file = "coverage-7.14.3-cp313-cp313-win32.whl", hash = "sha256:338b19131ab1a6b767b462bfcbaa692e7ae22f24463e39d49b02a83410ff6b37"},
+    {file = "coverage-7.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:b3d77f7f196abdef7e01415de1bce09f216189e83e58159cfeef2b92d0464994"},
+    {file = "coverage-7.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:e6230e688c7c3e65cedd41a774eb4ec221adc6bfee13768231015b702d5e4150"},
+    {file = "coverage-7.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:605ab2b566a22bd94834529d66d295c364aba84afd3e5498285c7a524017b1fc"},
+    {file = "coverage-7.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a3c2134809e80fac091bfed18a6991b5a5eb5df5ae32b17ac4f4f99864b73dd7"},
+    {file = "coverage-7.14.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c02efd507227bde9969cab0db8f48890eb3b5dcad6afac57a4792df4133543ce"},
+    {file = "coverage-7.14.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1bb93c2aa61d2a5b38f1526546d95cf4132cb681e541a337bf8dfd092be816e5"},
+    {file = "coverage-7.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f502e948e03e866538048bba081c075caaa62e5bda6ea5b7432e45f587eb462a"},
+    {file = "coverage-7.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9973ef2463f8e6cfb61a6324126bb3e17d67a85f22f58d856e583ea2e3ca6501"},
+    {file = "coverage-7.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9be4e7d4c5ca0427889f8f9d614bd630c2be741b1de7699bca3b2b6c0e41003e"},
+    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a574912f3bde4b0619f6e97d01aa590b70998859244793769eb3a6df78ee56d3"},
+    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e343fb086c9cd780b38622fea7c369acd64c1a0724312149b5d769c387a2b1f5"},
+    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:3c68df8e61f1e09633fefc7538297145623957a048534368c9d212782aa5e845"},
+    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3e5b550a128419373c2f6cec28a244207013ef15f5cbcff6a5ca09d1dfaaf027"},
+    {file = "coverage-7.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2bfc4dd0a912329eccc7484a7d0b2a38032b38c40663b1e1ac595f10c457954b"},
+    {file = "coverage-7.14.3-cp314-cp314-win32.whl", hash = "sha256:0423d64c013057a06e70f070f073cec4b0cbc7d2b27f3c7007292f2ff1d52965"},
+    {file = "coverage-7.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:92c22e19ce64ca3f2ad751f16f14df1468b4c231bd6af97185063a9c292a0cb3"},
+    {file = "coverage-7.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:41de778bd41780586e2b04912079c73089ab5d839624e28db3bdb26de638da92"},
+    {file = "coverage-7.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8427f370ca67db4c975d2a26acfc0e5783ca0b52444dbc50278ace0f35445949"},
+    {file = "coverage-7.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d8e88f335544a47e22ae2e45b344772925ec65166555c958720d5ed971880891"},
+    {file = "coverage-7.14.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:beaab199b9e5ceaf5a225e16a9d4df136f2a1eae0a5c20de1e277c8a5225f388"},
+    {file = "coverage-7.14.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ff255799f5a1676c71c1c32ec01fd043aa09d57b3d95764b24992757184784"},
+    {file = "coverage-7.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:878832eaac515b62decfa76965aed558775f86bf1fc8cca76993c0c84ae31aed"},
+    {file = "coverage-7.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:611e62cb9386096d81b63e0a05330750268617231e7bd598e1fe77482a2c58a5"},
+    {file = "coverage-7.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:02c41de2a88011b893050fc9830267d927a50a215f7ad5ec17349db7090ccf26"},
+    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:526ce9721116af23b1065089f0b75046fe521e7772ab94b641cd66b7a0421889"},
+    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e4ed44705ca4bead6fc977a8b741f2145608289b33c8a9b42a95d0f15aedbf4d"},
+    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2415902f385a23dcc4ccd26e0ba803249a169af6a930c003a4c715eeb9a5444e"},
+    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b75ee850fc2d7c831e883220c445b035f2224de2ba6103f1e56dbd237ab913f7"},
+    {file = "coverage-7.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dc9b4e35e7c3920e925ba7f14886fd5fbe481232754624e832ddba66c7535635"},
+    {file = "coverage-7.14.3-cp314-cp314t-win32.whl", hash = "sha256:7b27c822a8161afbe48e99f1adfb098d270ae7e0f7d7b0555ce110529bdb69cc"},
+    {file = "coverage-7.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:39e1dbbb6ff2c338e0196a482558a792a1de3aa64261196f5cdb3da016ad9cda"},
+    {file = "coverage-7.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:68520c90babfa2d560eca6d497921ed3a4f469623bd709733124491b2aa8ef3f"},
+    {file = "coverage-7.14.3-py3-none-any.whl", hash = "sha256:fb7e18afb6e903c1a92401a2f0501ac277dca527bb9ca6fe1f691a8a0026a0e8"},
+    {file = "coverage-7.14.3.tar.gz", hash = "sha256:1a7563a443f3d53fdeb040ec8c9f7466aed7ca3dc5891aa09d3ca3625fa4387f"},
 ]
 
 [package.extras]
@@ -2171,14 +2156,14 @@ typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de"},
-    {file = "pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa"},
+    {file = "pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440"},
+    {file = "pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f"},
 ]
 
 [package.dependencies]
@@ -2222,14 +2207,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "9.1.0"
+version = "9.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32"},
-    {file = "pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c"},
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
@@ -2587,14 +2572,14 @@ tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asy
 
 [[package]]
 name = "s3transfer"
-version = "0.18.0"
+version = "0.19.0"
 description = "An Amazon S3 Transfer Manager"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6"},
-    {file = "s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd"},
+    {file = "s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262"},
+    {file = "s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685"},
 ]
 
 [package.dependencies]
@@ -2859,21 +2844,20 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "tqdm"
-version = "4.68.2"
+version = "4.68.3"
 description = "Fast, Extensible Progress Meter"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "tqdm-4.68.2-py3-none-any.whl", hash = "sha256:d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede"},
-    {file = "tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add"},
+    {file = "tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03"},
+    {file = "tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482"},
 ]
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [package.extras]
-dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
 discord = ["envwrap", "requests"]
 notebook = ["ipywidgets (>=6)"]
 slack = ["envwrap", "slack-sdk"]
@@ -2990,102 +2974,102 @@ test = ["pytest (>=6.0.0)", "setuptools (>=77)"]
 
 [[package]]
 name = "wrapt"
-version = "2.2.1"
+version = "2.2.2"
 description = "Module for decorators, wrappers and monkey patching."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "wrapt-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0f68f478004475d97906686e702ddbddeaf717c0b68ad2794384308f2dc713ae"},
-    {file = "wrapt-2.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e422b2d647a65d6b080cad5accd09055d3809bdff00c76fba8dca00ca935572a"},
-    {file = "wrapt-2.2.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:036dfb40128819a751c6f451c6b9c10172c49e4c401aebcdb8ecf2aec1683598"},
-    {file = "wrapt-2.2.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09ac16c081bebfd15d8e4dfa5bdc805990bbd52249ecff22530da7a129d6120b"},
-    {file = "wrapt-2.2.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07be671fa8875971222b0ba9059ed8b4dc738631122feba17c93aa36b4213e9a"},
-    {file = "wrapt-2.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:93fc2bf40cd7f4a0256010dce073d44eeb4a351b9bca94d0477ce2b6e62532b3"},
-    {file = "wrapt-2.2.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ba519b2d765df9871a25879e6f7fa78948ea59a2a31f9c1a257e34b651994afc"},
-    {file = "wrapt-2.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9011395be8db1827d106c6449b4bb6dd17e331ff6ec521f227e4588f1c78e46f"},
-    {file = "wrapt-2.2.1-cp310-cp310-win32.whl", hash = "sha256:a8f7176b83664af44567e9cc06e0d3827823fcc1a5e52307ebb8ac3aa95860b9"},
-    {file = "wrapt-2.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:d7f513d3185e6fec82d0c3518f2e6365d8b4e49f5f45f29640d5162d56a23b54"},
-    {file = "wrapt-2.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:44255c84bc57554fed822e83e70036b51afa9edb56fc7ca56c54410ece7898c9"},
-    {file = "wrapt-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dd57607acc85678925940bd5df0385ff8332083a32fa8d7a43f8767f4997263c"},
-    {file = "wrapt-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1ae574d65c9fa8e86f64f6a7c2668f9fcd507b183e0e577619f504b883cb0a6c"},
-    {file = "wrapt-2.2.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9a04c28c10ba7fd12842b109d2edb0678872a2fe65277ca4ff06a0d61edee245"},
-    {file = "wrapt-2.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e2f02472a1cbbf3884b365714a810b5947134a95ad6952b554cb8cce9d492b0"},
-    {file = "wrapt-2.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac2745950b2bff80219c15ebf2fa9d8427eba7e249739f97e55c9d169e47e9e1"},
-    {file = "wrapt-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67a97e5b6c457f0cd3cfc19ebb2d84463e60c3ece754cc831e4281a3ca29bb18"},
-    {file = "wrapt-2.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c803a3d331796255af51ba2c79ed0ac8275865b516c09e61f248d1e7aff31ce9"},
-    {file = "wrapt-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9b984d1eb252145d6302c1dbd5e87fc6d404d45531447c84eadec04bf1fcb027"},
-    {file = "wrapt-2.2.1-cp311-cp311-win32.whl", hash = "sha256:8a983a603a18c8708f024f7f6991b2e66159219abbf894634c5056243c55f3cd"},
-    {file = "wrapt-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:9c210a6994b21aa9b29e81c8d11560e8fdab54c117e9cff37870d0a27bde1343"},
-    {file = "wrapt-2.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:401229e9d63ca09f9b8891ecf83798d26c11bbb445d11ed9f1836b6d4585b38a"},
-    {file = "wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0"},
-    {file = "wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8"},
-    {file = "wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e"},
-    {file = "wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926"},
-    {file = "wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624"},
-    {file = "wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710"},
-    {file = "wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f"},
-    {file = "wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797"},
-    {file = "wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052"},
-    {file = "wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5"},
-    {file = "wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579"},
-    {file = "wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb"},
-    {file = "wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80"},
-    {file = "wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a"},
-    {file = "wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474"},
-    {file = "wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143"},
-    {file = "wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a"},
-    {file = "wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9"},
-    {file = "wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31"},
-    {file = "wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337"},
-    {file = "wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215"},
-    {file = "wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f"},
-    {file = "wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8"},
-    {file = "wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8"},
-    {file = "wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d"},
-    {file = "wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27"},
-    {file = "wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440"},
-    {file = "wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e"},
-    {file = "wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b"},
-    {file = "wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394"},
-    {file = "wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562"},
-    {file = "wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53"},
-    {file = "wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e"},
-    {file = "wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab"},
-    {file = "wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c"},
-    {file = "wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c"},
-    {file = "wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e"},
-    {file = "wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f"},
-    {file = "wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508"},
-    {file = "wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5"},
-    {file = "wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283"},
-    {file = "wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243"},
-    {file = "wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b"},
-    {file = "wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36"},
-    {file = "wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188"},
-    {file = "wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199"},
-    {file = "wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413"},
-    {file = "wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956"},
-    {file = "wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e"},
-    {file = "wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85"},
-    {file = "wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181"},
-    {file = "wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a"},
-    {file = "wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85"},
-    {file = "wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50"},
-    {file = "wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00"},
-    {file = "wrapt-2.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5fa9bf3b9e66336589d03f42abce2da1055ad5c69b0c2b764852a8471c9b9114"},
-    {file = "wrapt-2.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:2076d2335085eb09b9547e7688656fa8f5cf0183eab589d33499cd353489d797"},
-    {file = "wrapt-2.2.1-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7975bc88ab4b0f72ef2a2d5ae9d77d87efb5ef95e8f8046242fa9afdaaf2030b"},
-    {file = "wrapt-2.2.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61a0013344674d2b648bc6e6fe9828dd4fc1d3b4eb7523809792f8cb952e2f16"},
-    {file = "wrapt-2.2.1-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b6c0febfe38f22df2eb565c0ce8a092bb80411e56861ca382c443da83105423f"},
-    {file = "wrapt-2.2.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:211f595f8e7faae5c5930fcc64708f2ba36849e0ba0fd653a843de9fa8d7db77"},
-    {file = "wrapt-2.2.1-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:f4e1a92032a39cd5e3c647ca57dbf33b6a1938fd975623175793f9dbb63236de"},
-    {file = "wrapt-2.2.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:24c52546acf2ab82412f2ab6fc5948a7fe958d3b4f070202e8dcdd865489eaf9"},
-    {file = "wrapt-2.2.1-cp39-cp39-win32.whl", hash = "sha256:c3723ff8eb8721f4daac98bc0256f15158e05316d5e52648ce9cebee434fbdd5"},
-    {file = "wrapt-2.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:2de9e20769fe9c1f6dcdc893c6a89287c5ccf8537c90b5de78aed8017697aad5"},
-    {file = "wrapt-2.2.1-cp39-cp39-win_arm64.whl", hash = "sha256:585916e210db57b23543342c2f298e42331b617fd0c934caf5c64df44de8640e"},
-    {file = "wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f"},
-    {file = "wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9"},
+    {file = "wrapt-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:055e6fcfaa28e58c6a8c247d48b92be9d56f818b7068aa4f22b15b3343a09931"},
+    {file = "wrapt-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8374eb6b1a58809211e84ff835a182bb17ab2807a5bfef23204c8cff38178a00"},
+    {file = "wrapt-2.2.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:656593bb3f5529f03d27af4136c4d7b11990e470bcbc6fefa5ef218695bece55"},
+    {file = "wrapt-2.2.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfb00cb7bb22099e2f64b7340fb96113639aa7260c0972af3797ace2297b936c"},
+    {file = "wrapt-2.2.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e7f10ee0bd53673bfd52b67cbce83336fe6cad90d2377b03baf66491d2bbfb91"},
+    {file = "wrapt-2.2.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4402f57c5f0d0579599858ffbdd9bf4e3f0972f51096f2bd6cc7dab6b76ee49e"},
+    {file = "wrapt-2.2.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:3a4eb7964ff4643d333c84f880bcf554652b2a1050aebc54ae696327f61acfaf"},
+    {file = "wrapt-2.2.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e542b7c5af91e2123a8aabf19894319d5ec4268d2a9ffd2f239386133fc47746"},
+    {file = "wrapt-2.2.2-cp310-cp310-win32.whl", hash = "sha256:6e7e45b43d3c774d244fe7264378f5a3f0f383bc55a54a9866434e524540110f"},
+    {file = "wrapt-2.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:955f1d6e72a352e478de8d8b503abe301c5e139a141b62eb0923bd694995025f"},
+    {file = "wrapt-2.2.2-cp310-cp310-win_arm64.whl", hash = "sha256:b89d8d73c82db2bb7e6090b3afd7973f980d24e905cc34394eab60b884b3bf67"},
+    {file = "wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73"},
+    {file = "wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e"},
+    {file = "wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d"},
+    {file = "wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328"},
+    {file = "wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5"},
+    {file = "wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0"},
+    {file = "wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae"},
+    {file = "wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099"},
+    {file = "wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c"},
+    {file = "wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971"},
+    {file = "wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30"},
+    {file = "wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b"},
+    {file = "wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb"},
+    {file = "wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a"},
+    {file = "wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900"},
+    {file = "wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79"},
+    {file = "wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a"},
+    {file = "wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf"},
+    {file = "wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab"},
+    {file = "wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da"},
+    {file = "wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f"},
+    {file = "wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8"},
+    {file = "wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69"},
+    {file = "wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617"},
+    {file = "wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e"},
+    {file = "wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d"},
+    {file = "wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b"},
+    {file = "wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c"},
+    {file = "wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f"},
+    {file = "wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94"},
+    {file = "wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d"},
+    {file = "wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4"},
+    {file = "wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac"},
+    {file = "wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5"},
+    {file = "wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec"},
+    {file = "wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9"},
+    {file = "wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c"},
+    {file = "wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194"},
+    {file = "wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066"},
+    {file = "wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20"},
+    {file = "wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af"},
+    {file = "wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9"},
+    {file = "wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28"},
+    {file = "wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0"},
+    {file = "wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745"},
+    {file = "wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00"},
+    {file = "wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc"},
+    {file = "wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95"},
+    {file = "wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33"},
+    {file = "wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab"},
+    {file = "wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663"},
+    {file = "wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d"},
+    {file = "wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56"},
+    {file = "wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406"},
+    {file = "wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c"},
+    {file = "wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a"},
+    {file = "wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063"},
+    {file = "wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f"},
+    {file = "wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81"},
+    {file = "wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c"},
+    {file = "wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff"},
+    {file = "wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5"},
+    {file = "wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c"},
+    {file = "wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca"},
+    {file = "wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77"},
+    {file = "wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347"},
+    {file = "wrapt-2.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d01d8e0afc55823245a3b97a79c7c77464e31ea7a7b629a4bf26f9441dc1f18e"},
+    {file = "wrapt-2.2.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a28287413351cb198b8c5ddd045c56fac1d195808642cd264d1ab50426146650"},
+    {file = "wrapt-2.2.2-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:abf033b7e4542357659cd83ed6cd5033c43aaa1887044045ceb571528837f72f"},
+    {file = "wrapt-2.2.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d2f6573561fa05002e5ee71529f4ab0a7dffed3e45b51013fe6298fe2723c02"},
+    {file = "wrapt-2.2.2-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c38510a21d5b9cf3e84c460d909e9f2a098667439fd42841bb081cab45835d68"},
+    {file = "wrapt-2.2.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:cd385a48b055bdc3630ab30e0c7fd8514a36904ec23f9cee7a65d887334a3cea"},
+    {file = "wrapt-2.2.2-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:3dc3dcfc2da95d501905f10dc11a0dc622e91d8cdd8bbfcb63ca54afd131e556"},
+    {file = "wrapt-2.2.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:fa81c5b5fe8cd6c41e3a798533b81288279e5fdbde2128f21071922764281c99"},
+    {file = "wrapt-2.2.2-cp39-cp39-win32.whl", hash = "sha256:814f1bf3e0a7035f67a1db0cdaf5e2bbcaa4d7092db96673cfa467adeaab8591"},
+    {file = "wrapt-2.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:9ee098171b07edba66ab69a9bf0251d3cbef654107e800feb24c0c6f30592728"},
+    {file = "wrapt-2.2.2-cp39-cp39-win_arm64.whl", hash = "sha256:3179a4db066b53d40562e368b12895440c8f0953b6543b89d6acc41c0273996e"},
+    {file = "wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048"},
+    {file = "wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302"},
 ]
 
 [package.extras]

--- a/tests/backends/test_backends_s3.py
+++ b/tests/backends/test_backends_s3.py
@@ -66,6 +66,81 @@ class TestS3BackendInit:
         ):
             S3Backend(mock_authenticators, "test-deployment")
 
+    @pytest.mark.parametrize(
+        "error_factory,error_args",
+        [
+            (
+                botocore.exceptions.TokenRetrievalError,
+                {"provider": "sso", "error_msg": "Token has expired"},
+            ),
+            (botocore.exceptions.NoCredentialsError, {}),
+            (
+                botocore.exceptions.PartialCredentialsError,
+                {"provider": "test", "cred_var": "AWS_SECRET_ACCESS_KEY"},
+            ),
+        ],
+        ids=["token_retrieval", "no_credentials", "partial_credentials"],
+    )
+    @mock_aws
+    def test_init_auth_errors(
+        self, mock_authenticators, mocker, error_factory, error_args
+    ):
+        """Test that various auth errors raise helpful BackendError."""
+        error = error_factory(**error_args)
+        mocker.patch.object(S3Backend, "_check_table_exists", side_effect=error)
+
+        with pytest.raises(
+            BackendError, match="AWS authentication failed:"
+        ) as exc_info:
+            S3Backend(mock_authenticators, "test-deployment")
+
+        assert exc_info.value.__cause__ is error
+
+    @pytest.mark.parametrize(
+        "error_code",
+        [
+            "ExpiredToken",
+            "InvalidClientTokenId",
+            "SignatureDoesNotMatch",
+            "AccessDenied",
+        ],
+        ids=["expired_token", "invalid_token", "bad_signature", "access_denied"],
+    )
+    @mock_aws
+    def test_init_client_error_auth_codes(
+        self, mock_authenticators, mocker, error_code
+    ):
+        """Test that ClientError with auth codes raises helpful BackendError."""
+        client_error = botocore.exceptions.ClientError(
+            {"Error": {"Code": error_code, "Message": "Auth error"}},
+            "DescribeTable",
+        )
+        mocker.patch.object(S3Backend, "_check_table_exists", side_effect=client_error)
+
+        with pytest.raises(
+            BackendError, match="AWS authentication failed:"
+        ) as exc_info:
+            S3Backend(mock_authenticators, "test-deployment")
+
+        assert exc_info.value.__cause__ is client_error
+
+    @mock_aws
+    def test_init_non_auth_client_error(self, mock_authenticators, mocker):
+        """Test that non-auth ClientError is re-raised."""
+        client_error = botocore.exceptions.ClientError(
+            {"Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}},
+            "DescribeTable",
+        )
+        mocker.patch.object(
+            S3Backend,
+            "_check_table_exists",
+            side_effect=client_error,
+        )
+
+        # Should re-raise the original ClientError, not BackendError
+        with pytest.raises(botocore.exceptions.ClientError):
+            S3Backend(mock_authenticators, "test-deployment")
+
 
 class TestS3BackendCheckBucketExists:
 

--- a/tests/definitions/test_definitions_prepare_extra.py
+++ b/tests/definitions/test_definitions_prepare_extra.py
@@ -123,7 +123,9 @@ def test_vars_typer_complex():
 
 
 def test_create_local_vars(mocker, def_prepare, definition):
-    mocker.patch.object(Definition, "get_remote_vars", return_value={"foo": "bar"})
+    mocker.patch.object(
+        Definition, "get_remote_vars", return_value={"foo": "bar.outputs.baz"}
+    )
     def_prepare.create_local_vars("def1")
     outfile = (
         Path(definition.get_target_path(def_prepare._app_state.working_dir))
@@ -131,7 +133,7 @@ def test_create_local_vars(mocker, def_prepare, definition):
     )
     assert (
         outfile.read_text()
-        == "locals {\n  foo = data.terraform_remote_state.bar\n}\n\n"
+        == "locals {\n  foo = data.terraform_remote_state.bar.outputs.baz\n}\n\n"
     )
 
 
@@ -233,15 +235,17 @@ def test_get_provider_content(def_prepare, mocker, definition):
 
 
 def test_get_remotes(def_prepare, mocker, definition):
-    definition.remote_vars = {"a": "one.var", "b": "two.var"}
+    definition.remote_vars = {"a": "one.outputs.var", "b": "two.outputs.var"}
     def_prepare._app_state.terraform_options.backend_use_all_remotes = False
     def_prepare._app_state.backend.remotes = ["x", "y"]
 
     mock_get_remote_vars = mocker.patch.object(
-        Definition, "get_remote_vars", return_value={"a": "one.var", "b": "two.var"}
+        Definition,
+        "get_remote_vars",
+        return_value={"a": "one.outputs.var", "b": "two.outputs.var"},
     )
 
-    assert def_prepare._get_remotes("def1") == ["one", "two"]
+    assert set(def_prepare._get_remotes("def1")) == {"one", "two"}
     mock_get_remote_vars.assert_called_once_with(
         global_vars=def_prepare._app_state.loaded_config.global_vars.remote_vars
     )
@@ -251,17 +255,20 @@ def test_get_remotes(def_prepare, mocker, definition):
 
 
 def test_get_remotes_with_global_inheritance(def_prepare, mocker, definition):
-    definition.remote_vars = {"local_var": "local.state"}
+    definition.remote_vars = {"local_var": "local.outputs.state"}
     def_prepare._app_state.terraform_options.backend_use_all_remotes = False
 
     mock_get_remote_vars = mocker.patch.object(
         Definition,
         "get_remote_vars",
-        return_value={"local_var": "local.state", "global_var": "global.state"},
+        return_value={
+            "local_var": "local.outputs.state",
+            "global_var": "global.outputs.state",
+        },
     )
 
     result = def_prepare._get_remotes("def1")
-    assert result == ["local", "global"]
+    assert set(result) == {"local", "global"}
     mock_get_remote_vars.assert_called_once_with(
         global_vars=def_prepare._app_state.loaded_config.global_vars.remote_vars
     )
@@ -292,3 +299,337 @@ def test_get_template_vars(mocker, def_prepare, definition, monkeypatch):
     assert result["var"]["foo"] == "bar"
     assert result["var"]["baz"] == "qux"
     assert result["env"]["EXAMPLE"] == "value"
+
+
+# ===== Tests for nested remote_vars structures =====
+
+
+class TestCreateLocalVarsNested:
+    """Tests for create_local_vars with nested structures (dicts/lists)."""
+
+    def test_create_local_vars_with_dict_entire_outputs(
+        self, mocker, def_prepare, definition
+    ):
+        """Test creating locals with dict of entire outputs references."""
+        remote_vars = {
+            "vpcs": {
+                "platform": "network1.outputs",
+                "payments": "network2.outputs",
+            }
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        # Check structure
+        assert "locals {" in content
+        assert "vpcs = {" in content
+        assert '"platform" = data.terraform_remote_state.network1.outputs' in content
+        assert '"payments" = data.terraform_remote_state.network2.outputs' in content
+
+    def test_create_local_vars_with_dict_specific_keys(
+        self, mocker, def_prepare, definition
+    ):
+        """Test creating locals with dict of specific output keys."""
+        remote_vars = {
+            "vpc_configs": {
+                "platform": "network1.outputs.vpc_config",
+                "payments": "network2.outputs.vpc_config",
+            }
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        assert "vpc_configs = {" in content
+        assert (
+            '"platform" = data.terraform_remote_state.network1.outputs.vpc_config'
+            in content
+        )
+        assert (
+            '"payments" = data.terraform_remote_state.network2.outputs.vpc_config'
+            in content
+        )
+
+    def test_create_local_vars_with_list(self, mocker, def_prepare, definition):
+        """Test creating locals with list of references."""
+        remote_vars = {
+            "vpc_ids": [
+                "network1.outputs.vpc_id",
+                "network2.outputs.vpc_id",
+                "network3.outputs.vpc_id",
+            ]
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        assert "vpc_ids = [" in content
+        assert "data.terraform_remote_state.network1.outputs.vpc_id," in content
+        assert "data.terraform_remote_state.network2.outputs.vpc_id," in content
+        assert "data.terraform_remote_state.network3.outputs.vpc_id," in content
+
+    def test_create_local_vars_mixed_simple_and_complex(
+        self, mocker, def_prepare, definition
+    ):
+        """Test creating locals with mix of simple strings and complex structures."""
+        remote_vars = {
+            # Simple (existing)
+            "environment": "env_info.outputs.environment",
+            # Dict
+            "vpcs": {
+                "platform": "network1.outputs",
+                "payments": "network2.outputs",
+            },
+            # List
+            "vpc_ids": [
+                "network1.outputs.vpc_id",
+                "network2.outputs.vpc_id",
+            ],
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        # Simple string
+        assert (
+            "environment = data.terraform_remote_state.env_info.outputs.environment"
+            in content
+        )
+        # Dict
+        assert "vpcs = {" in content
+        assert '"platform" = data.terraform_remote_state.network1.outputs' in content
+        # List
+        assert "vpc_ids = [" in content
+        assert "data.terraform_remote_state.network1.outputs.vpc_id," in content
+
+    def test_create_local_vars_nested_dict_in_dict(
+        self, mocker, def_prepare, definition
+    ):
+        """Test creating locals with nested dict structures."""
+        remote_vars = {
+            "networks": {
+                "production": {
+                    "primary": "net1.outputs.vpc",
+                    "secondary": "net2.outputs.vpc",
+                },
+                "staging": {
+                    "primary": "net3.outputs.vpc",
+                },
+            }
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        assert "networks = {" in content
+        assert '"production" = {' in content
+        assert '"primary" = data.terraform_remote_state.net1.outputs.vpc' in content
+        assert '"secondary" = data.terraform_remote_state.net2.outputs.vpc' in content
+        assert '"staging" = {' in content
+        assert '"primary" = data.terraform_remote_state.net3.outputs.vpc' in content
+
+    def test_create_local_vars_empty_dict(self, mocker, def_prepare, definition):
+        """Test creating locals with empty dict."""
+        remote_vars = {"empty": {}}
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        assert "empty = {}" in content
+
+    def test_create_local_vars_empty_list(self, mocker, def_prepare, definition):
+        """Test creating locals with empty list."""
+        remote_vars = {"empty": []}
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare.create_local_vars("def1")
+
+        outfile = (
+            Path(definition.get_target_path(def_prepare._app_state.working_dir))
+            / WORKER_LOCALS_FILENAME
+        )
+        content = outfile.read_text()
+
+        assert "empty = []" in content
+
+
+class TestGetRemotesNested:
+    """Tests for _get_remotes with nested structures."""
+
+    def test_get_remotes_from_dict(self, mocker, def_prepare, definition):
+        """Test extracting remotes from dict structure."""
+        remote_vars = {
+            "vpcs": {
+                "platform": "network1.outputs",
+                "payments": "network2.outputs.vpc",
+            }
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare._app_state.terraform_options.backend_use_all_remotes = False
+
+        remotes = def_prepare._get_remotes("def1")
+        assert set(remotes) == {"network1", "network2"}
+
+    def test_get_remotes_from_list(self, mocker, def_prepare, definition):
+        """Test extracting remotes from list structure."""
+        remote_vars = {
+            "vpc_ids": [
+                "net1.outputs.vpc_id",
+                "net2.outputs.vpc_id",
+                "net3.outputs.vpc_id",
+            ]
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare._app_state.terraform_options.backend_use_all_remotes = False
+
+        remotes = def_prepare._get_remotes("def1")
+        assert set(remotes) == {"net1", "net2", "net3"}
+
+    def test_get_remotes_from_mixed_structures(self, mocker, def_prepare, definition):
+        """Test extracting remotes from mixed simple and complex structures."""
+        remote_vars = {
+            "env": "env_info.outputs.environment",
+            "vpcs": {
+                "platform": "network1.outputs",
+                "payments": "network2.outputs",
+            },
+            "db_endpoints": [
+                "db1.outputs.endpoint",
+                "db2.outputs.endpoint",
+            ],
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare._app_state.terraform_options.backend_use_all_remotes = False
+
+        remotes = def_prepare._get_remotes("def1")
+        assert set(remotes) == {"env_info", "network1", "network2", "db1", "db2"}
+
+    def test_get_remotes_deduplicates(self, mocker, def_prepare, definition):
+        """Test that duplicate state names are deduplicated."""
+        remote_vars = {
+            "vpc_id": "net1.outputs.vpc_id",
+            "subnet_ids": "net1.outputs.subnet_ids",
+            "cidr": "net1.outputs.cidr",
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare._app_state.terraform_options.backend_use_all_remotes = False
+
+        remotes = def_prepare._get_remotes("def1")
+        assert remotes == ["net1"]
+
+    def test_get_remotes_with_nested_dict(self, mocker, def_prepare, definition):
+        """Test extracting remotes from deeply nested structures."""
+        remote_vars = {
+            "networks": {
+                "production": {
+                    "primary": "net1.outputs",
+                    "secondary": "net2.outputs",
+                },
+                "staging": [
+                    "net3.outputs.vpc_id",
+                ],
+            }
+        }
+        mocker.patch.object(Definition, "get_remote_vars", return_value=remote_vars)
+        def_prepare._app_state.terraform_options.backend_use_all_remotes = False
+
+        remotes = def_prepare._get_remotes("def1")
+        assert set(remotes) == {"net1", "net2", "net3"}
+
+
+class TestGenerateTfValue:
+    """Tests for _generate_tf_value helper method."""
+
+    def test_generate_simple_string(self, def_prepare):
+        """Test generating HCL for simple string reference."""
+        result = def_prepare._generate_tf_value("network1.outputs.vpc_id")
+        assert result == "data.terraform_remote_state.network1.outputs.vpc_id"
+
+    def test_generate_string_entire_outputs(self, def_prepare):
+        """Test generating HCL for entire outputs reference."""
+        result = def_prepare._generate_tf_value("network1.outputs")
+        assert result == "data.terraform_remote_state.network1.outputs"
+
+    def test_generate_dict_single_level(self, def_prepare):
+        """Test generating HCL for single-level dict."""
+        value = {
+            "platform": "network1.outputs",
+            "payments": "network2.outputs",
+        }
+        result = def_prepare._generate_tf_value(value, indent=1)
+
+        assert "{" in result
+        assert '"platform" = data.terraform_remote_state.network1.outputs' in result
+        assert '"payments" = data.terraform_remote_state.network2.outputs' in result
+        assert "}" in result
+
+    def test_generate_list(self, def_prepare):
+        """Test generating HCL for list."""
+        value = [
+            "net1.outputs.vpc_id",
+            "net2.outputs.vpc_id",
+        ]
+        result = def_prepare._generate_tf_value(value, indent=1)
+
+        assert "[" in result
+        assert "data.terraform_remote_state.net1.outputs.vpc_id," in result
+        assert "data.terraform_remote_state.net2.outputs.vpc_id," in result
+        assert "]" in result
+
+    def test_generate_empty_dict(self, def_prepare):
+        """Test generating HCL for empty dict."""
+        result = def_prepare._generate_tf_value({})
+        assert result == "{}"
+
+    def test_generate_empty_list(self, def_prepare):
+        """Test generating HCL for empty list."""
+        result = def_prepare._generate_tf_value([])
+        assert result == "[]"
+
+    def test_generate_nested_dict(self, def_prepare):
+        """Test generating HCL for nested dict."""
+        value = {
+            "production": {
+                "primary": "net1.outputs",
+            }
+        }
+        result = def_prepare._generate_tf_value(value, indent=1)
+
+        assert '"production" = {' in result
+        assert '"primary" = data.terraform_remote_state.net1.outputs' in result
+
+    def test_generate_invalid_type(self, def_prepare):
+        """Test that invalid value type raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            def_prepare._generate_tf_value(123)  # Number not supported
+        assert "Unsupported remote_vars value type" in str(exc_info.value)

--- a/tests/util/test_util_hooks.py
+++ b/tests/util/test_util_hooks.py
@@ -533,3 +533,529 @@ class TestHelperFunctions:
         extra_vars = {"extra_key": "extra_value"}
         hooks._populate_environment_with_extra_vars(local_env, extra_vars, False)
         assert "TF_EXTRA_EXTRA_KEY" in local_env
+
+
+# Tests for nested remote_vars structures
+class TestResolveTerraformValue:
+    """Tests for _resolve_terraform_value() function."""
+
+    def test_resolve_simple_string_with_specific_output(self):
+        """Test resolving a simple terraform_remote_state reference to specific output."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.return_value = {
+            "version": 4,
+            "outputs": {
+                "vpc_id": {"value": "vpc-123", "type": "string"},
+            },
+            "resources": [],
+        }
+
+        state_cache = {}
+        value = "data.terraform_remote_state.network1.outputs.vpc_id"
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == "vpc-123"
+        mock_backend.get_state.assert_called_once_with("network1")
+
+    def test_resolve_string_with_entire_outputs(self):
+        """Test resolving terraform_remote_state reference to entire outputs dict."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.return_value = {
+            "version": 4,
+            "outputs": {
+                "vpc_id": {"value": "vpc-123", "type": "string"},
+                "subnet_ids": {"value": ["subnet-1", "subnet-2"], "type": "list"},
+            },
+            "resources": [],
+        }
+
+        state_cache = {}
+        value = "data.terraform_remote_state.network1.outputs"
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == {
+            "vpc_id": "vpc-123",
+            "subnet_ids": ["subnet-1", "subnet-2"],
+        }
+        mock_backend.get_state.assert_called_once_with("network1")
+
+    def test_resolve_plain_string(self):
+        """Test that plain strings (non-terraform refs) pass through unchanged."""
+        mock_backend = mock.Mock()
+        state_cache = {}
+
+        result = hooks._resolve_terraform_value(
+            "plain_string", mock_backend, state_cache
+        )
+        assert result == "plain_string"
+        mock_backend.get_state.assert_not_called()
+
+    def test_resolve_dict_with_terraform_refs(self):
+        """Test resolving dict with terraform_remote_state references as values."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.side_effect = [
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-123", "type": "string"},
+                },
+                "resources": [],
+            },
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-456", "type": "string"},
+                },
+                "resources": [],
+            },
+        ]
+
+        state_cache = {}
+        value = {
+            "platform": "data.terraform_remote_state.network1.outputs.vpc_id",
+            "payments": "data.terraform_remote_state.network2.outputs.vpc_id",
+        }
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == {
+            "platform": "vpc-123",
+            "payments": "vpc-456",
+        }
+        assert mock_backend.get_state.call_count == 2
+
+    def test_resolve_dict_with_entire_outputs(self):
+        """Test resolving dict where values are entire outputs dicts."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.side_effect = [
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-123", "type": "string"},
+                    "cidr": {"value": "10.0.0.0/16", "type": "string"},
+                },
+                "resources": [],
+            },
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-456", "type": "string"},
+                    "cidr": {"value": "10.1.0.0/16", "type": "string"},
+                },
+                "resources": [],
+            },
+        ]
+
+        state_cache = {}
+        value = {
+            "platform": "data.terraform_remote_state.network1.outputs",
+            "payments": "data.terraform_remote_state.network2.outputs",
+        }
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == {
+            "platform": {"vpc_id": "vpc-123", "cidr": "10.0.0.0/16"},
+            "payments": {"vpc_id": "vpc-456", "cidr": "10.1.0.0/16"},
+        }
+
+    def test_resolve_list_with_terraform_refs(self):
+        """Test resolving list with terraform_remote_state references."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.side_effect = [
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-123", "type": "string"},
+                },
+                "resources": [],
+            },
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-456", "type": "string"},
+                },
+                "resources": [],
+            },
+        ]
+
+        state_cache = {}
+        value = [
+            "data.terraform_remote_state.network1.outputs.vpc_id",
+            "data.terraform_remote_state.network2.outputs.vpc_id",
+        ]
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == ["vpc-123", "vpc-456"]
+        assert mock_backend.get_state.call_count == 2
+
+    def test_resolve_nested_dict(self):
+        """Test resolving deeply nested dict structures."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.return_value = {
+            "version": 4,
+            "outputs": {
+                "vpc_id": {"value": "vpc-123", "type": "string"},
+            },
+            "resources": [],
+        }
+
+        state_cache = {}
+        value = {
+            "production": {
+                "primary": "data.terraform_remote_state.network1.outputs.vpc_id",
+            }
+        }
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == {"production": {"primary": "vpc-123"}}
+
+    def test_resolve_with_caching(self):
+        """Test that state caching prevents duplicate backend calls."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.return_value = {
+            "version": 4,
+            "outputs": {
+                "vpc_id": {"value": "vpc-123", "type": "string"},
+                "subnet_id": {"value": "subnet-456", "type": "string"},
+            },
+            "resources": [],
+        }
+
+        state_cache = {}
+        value = {
+            "vpc": "data.terraform_remote_state.network1.outputs.vpc_id",
+            "subnet": "data.terraform_remote_state.network1.outputs.subnet_id",
+        }
+        result = hooks._resolve_terraform_value(value, mock_backend, state_cache)
+
+        assert result == {"vpc": "vpc-123", "subnet": "subnet-456"}
+        # Should only call backend once due to caching
+        mock_backend.get_state.assert_called_once_with("network1")
+
+    def test_resolve_literal_values(self):
+        """Test that literal values (int, bool, etc.) pass through unchanged."""
+        mock_backend = mock.Mock()
+        state_cache = {}
+
+        assert hooks._resolve_terraform_value(42, mock_backend, state_cache) == 42
+        assert hooks._resolve_terraform_value(True, mock_backend, state_cache) is True
+        assert hooks._resolve_terraform_value(None, mock_backend, state_cache) is None
+
+    def test_resolve_output_not_found(self):
+        """Test error when requested output doesn't exist."""
+        mock_backend = mock.Mock()
+        mock_backend.get_state.return_value = {
+            "version": 4,
+            "outputs": {
+                "vpc_id": {"value": "vpc-123", "type": "string"},
+            },
+            "resources": [],
+        }
+
+        state_cache = {}
+        value = "data.terraform_remote_state.network1.outputs.nonexistent"
+
+        with pytest.raises(hooks.HookError) as exc_info:
+            hooks._resolve_terraform_value(value, mock_backend, state_cache)
+        assert "Output 'nonexistent' not found" in str(exc_info.value)
+
+
+class TestPopulateEnvironmentWithNestedRemoteVars:
+    """Tests for _populate_environment_with_terraform_remote_vars with nested structures."""
+
+    @mock.patch("builtins.open", new_callable=mock.mock_open)
+    @mock.patch("tfworker.util.hooks.os.path.isfile", return_value=True)
+    @mock.patch("tfworker.util.hooks.hcl2.loads")
+    def test_populate_with_dict_of_entire_outputs(
+        self, mock_hcl2_loads, mock_isfile, mock_open
+    ):
+        """Test populating environment with dict of entire outputs."""
+        mock_open.return_value.read.return_value = """locals {
+  vpcs = {
+    "platform" = data.terraform_remote_state.network1.outputs
+    "payments" = data.terraform_remote_state.network2.outputs
+  }
+}
+"""
+        mock_hcl2_loads.return_value = {
+            "locals": [
+                {
+                    "vpcs": {
+                        "platform": "data.terraform_remote_state.network1.outputs",
+                        "payments": "data.terraform_remote_state.network2.outputs",
+                    }
+                }
+            ]
+        }
+
+        mock_backend = mock.Mock()
+        mock_backend.get_state.side_effect = [
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-123", "type": "string"},
+                },
+                "resources": [],
+            },
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-456", "type": "string"},
+                },
+                "resources": [],
+            },
+        ]
+
+        local_env = {}
+        hooks._populate_environment_with_terraform_remote_vars(
+            local_env, "working_dir", "terraform_path", False, mock_backend
+        )
+
+        assert "TF_REMOTE_VPCS" in local_env
+        # Should be JSON-encoded dict with nested dicts
+        import json
+
+        vpcs_value = json.loads(local_env["TF_REMOTE_VPCS"].strip("'"))
+        assert vpcs_value == {
+            "platform": {"vpc_id": "vpc-123"},
+            "payments": {"vpc_id": "vpc-456"},
+        }
+
+    @mock.patch("builtins.open", new_callable=mock.mock_open)
+    @mock.patch("tfworker.util.hooks.os.path.isfile", return_value=True)
+    @mock.patch("tfworker.util.hooks.hcl2.loads")
+    def test_populate_with_list(self, mock_hcl2_loads, mock_isfile, mock_open):
+        """Test populating environment with list of references."""
+        mock_open.return_value.read.return_value = """locals {
+  vpc_ids = [
+    data.terraform_remote_state.network1.outputs.vpc_id,
+    data.terraform_remote_state.network2.outputs.vpc_id,
+  ]
+}
+"""
+        mock_hcl2_loads.return_value = {
+            "locals": [
+                {
+                    "vpc_ids": [
+                        "data.terraform_remote_state.network1.outputs.vpc_id",
+                        "data.terraform_remote_state.network2.outputs.vpc_id",
+                    ]
+                }
+            ]
+        }
+
+        mock_backend = mock.Mock()
+        mock_backend.get_state.side_effect = [
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-123", "type": "string"},
+                },
+                "resources": [],
+            },
+            {
+                "version": 4,
+                "outputs": {
+                    "vpc_id": {"value": "vpc-456", "type": "string"},
+                },
+                "resources": [],
+            },
+        ]
+
+        local_env = {}
+        hooks._populate_environment_with_terraform_remote_vars(
+            local_env, "working_dir", "terraform_path", False, mock_backend
+        )
+
+        assert "TF_REMOTE_VPC_IDS" in local_env
+        # Should be JSON-encoded list
+        import json
+
+        vpc_ids_value = json.loads(local_env["TF_REMOTE_VPC_IDS"].strip("'"))
+        assert vpc_ids_value == ["vpc-123", "vpc-456"]
+
+    @mock.patch("builtins.open", new_callable=mock.mock_open)
+    @mock.patch("tfworker.util.hooks.os.path.isfile", return_value=True)
+    @mock.patch("tfworker.util.hooks.hcl2.loads")
+    def test_fallback_to_regex_on_hcl2_parse_failure(
+        self, mock_hcl2_loads, mock_isfile, mock_open
+    ):
+        """Test that regex fallback works when HCL2 parsing fails."""
+        mock_locals_content = """locals {
+  local_key = data.terraform_remote_state.example.outputs.key
+}
+"""
+        mock_open.return_value.read.return_value = mock_locals_content
+        # Make HCL2 parsing fail
+        mock_hcl2_loads.side_effect = Exception("HCL2 parse error")
+
+        mock_backend = mock.Mock()
+        mock_backend.get_state.return_value = {
+            "version": 4,
+            "outputs": {
+                "key": {"value": "test_value", "type": "string"},
+            },
+            "resources": [],
+        }
+
+        local_env = {}
+        # Should fall back to regex parsing
+        with mock.patch(
+            "tfworker.util.hooks.get_state_item",
+            return_value='{"value":"test_value","type":"string"}',
+        ):
+            hooks._populate_environment_with_terraform_remote_vars(
+                local_env, "working_dir", "terraform_path", False, mock_backend
+            )
+
+        assert "TF_REMOTE_LOCAL_KEY" in local_env
+        assert local_env["TF_REMOTE_LOCAL_KEY"] == "test_value"
+
+
+class TestCheckEnvVarSize:
+    """Tests for _check_env_var_size() function."""
+
+    def test_small_variable_no_warning(self, monkeypatch):
+        """Test that small variables don't trigger warnings."""
+        mock_warn = mock.Mock()
+        mock_info = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.warn", mock_warn)
+        monkeypatch.setattr("tfworker.util.hooks.log.info", mock_info)
+
+        hooks._check_env_var_size("TEST_VAR", "small value", b64_encode=False)
+
+        # Should not log anything for small values
+        mock_warn.assert_not_called()
+        mock_info.assert_not_called()
+
+    def test_variable_approaching_limit_info(self, monkeypatch):
+        """Test that variables approaching limit (>80%) trigger info log."""
+        mock_info = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.info", mock_info)
+        monkeypatch.setenv("SHELL", "/bin/sh")
+
+        # sh limit is 65536, so 85% is ~55705 bytes
+        large_value = "x" * 55705
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=False)
+
+        mock_info.assert_called_once()
+        call_arg = mock_info.call_args[0][0]
+        assert "TEST_VAR" in call_arg
+        assert "approaching the sh limit" in call_arg
+        assert "84% of limit" in call_arg or "85% of limit" in call_arg
+
+    def test_variable_exceeding_limit_warning(self, monkeypatch):
+        """Test that variables exceeding limit trigger warning."""
+        mock_warn = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.warn", mock_warn)
+        monkeypatch.setenv("SHELL", "/bin/sh")
+
+        # sh limit is 65536, create value larger than that
+        large_value = "x" * 70000
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=False)
+
+        mock_warn.assert_called_once()
+        call_arg = mock_warn.call_args[0][0]
+        assert "TEST_VAR" in call_arg
+        assert "exceeds the typical sh limit" in call_arg
+        assert "70,000 bytes" in call_arg
+
+    def test_base64_encoded_note_in_warning(self, monkeypatch):
+        """Test that base64 encoding is noted in warning message."""
+        mock_warn = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.warn", mock_warn)
+        monkeypatch.setenv("SHELL", "/bin/sh")
+
+        large_value = "x" * 70000
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=True)
+
+        mock_warn.assert_called_once()
+        call_arg = mock_warn.call_args[0][0]
+        assert "(base64 encoded)" in call_arg
+
+    def test_bash_shell_limit(self, monkeypatch):
+        """Test that bash shell uses higher limit (128 KB)."""
+        mock_info = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.info", mock_info)
+        monkeypatch.setenv("SHELL", "/bin/bash")
+
+        # bash limit is 131072, so 85% is ~111411 bytes
+        large_value = "x" * 111411
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=False)
+
+        mock_info.assert_called_once()
+        call_arg = mock_info.call_args[0][0]
+        assert "approaching the bash limit of 131,072 bytes" in call_arg
+
+    def test_zsh_shell_limit(self, monkeypatch):
+        """Test that zsh shell uses highest limit (1 MB)."""
+        mock_info = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.info", mock_info)
+        monkeypatch.setenv("SHELL", "/usr/bin/zsh")
+
+        # zsh limit is 1048576, so 85% is ~891289 bytes
+        large_value = "x" * 891289
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=False)
+
+        mock_info.assert_called_once()
+        call_arg = mock_info.call_args[0][0]
+        assert "approaching the zsh limit of 1,048,576 bytes" in call_arg
+
+    def test_unknown_shell_uses_conservative_limit(self, monkeypatch):
+        """Test that unknown/missing shell uses conservative sh limit."""
+        mock_warn = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.warn", mock_warn)
+        monkeypatch.setenv("SHELL", "/usr/bin/unknown")
+
+        # Should default to sh limit (65536)
+        large_value = "x" * 70000
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=False)
+
+        mock_warn.assert_called_once()
+        call_arg = mock_warn.call_args[0][0]
+        assert "exceeds the typical unknown limit" in call_arg
+
+    def test_no_shell_env_uses_conservative_limit(self, monkeypatch):
+        """Test that missing SHELL env var uses conservative sh limit."""
+        mock_warn = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.warn", mock_warn)
+        monkeypatch.delenv("SHELL", raising=False)
+
+        # Should default to sh limit (65536)
+        large_value = "x" * 70000
+
+        hooks._check_env_var_size("TEST_VAR", large_value, b64_encode=False)
+
+        mock_warn.assert_called_once()
+        call_arg = mock_warn.call_args[0][0]
+        # When SHELL is not set, current_shell defaults to "sh"
+        assert "exceeds the typical sh limit" in call_arg
+
+
+class TestSetHookEnvVarWithSizeCheck:
+    """Test that _set_hook_env_var integrates size checking."""
+
+    def test_set_hook_env_var_with_large_dict_warns(self, monkeypatch):
+        """Test that setting large nested dict triggers size warning."""
+        mock_warn = mock.Mock()
+        monkeypatch.setattr("tfworker.util.hooks.log.warn", mock_warn)
+        monkeypatch.setenv("SHELL", "/bin/sh")
+
+        local_env = {}
+        # Create a large dict that exceeds sh limit (65536 bytes)
+        large_dict = {f"key_{i}": f"value_{i}" * 100 for i in range(1000)}
+
+        hooks._set_hook_env_var(
+            local_env, hooks.TFHookVarType.REMOTE, "LARGE_VAR", large_dict, False
+        )
+
+        assert "TF_REMOTE_LARGE_VAR" in local_env
+        # Should have logged a warning
+        mock_warn.assert_called_once()
+        call_arg = mock_warn.call_args[0][0]
+        assert "exceeds the typical" in call_arg

--- a/tests/util/test_util_remote_vars.py
+++ b/tests/util/test_util_remote_vars.py
@@ -1,0 +1,479 @@
+"""Unit tests for tfworker.util.remote_vars module."""
+
+import pytest
+
+from tfworker.util.remote_vars import (
+    extract_remote_states,
+    generate_tf_reference,
+    parse_remote_var_reference,
+    parse_tf_reference,
+    validate_remote_vars,
+)
+
+
+class TestParseRemoteVarReference:
+    """Tests for parse_remote_var_reference() function."""
+
+    @pytest.mark.parametrize(
+        "input_ref,expected_state,expected_key",
+        [
+            ("network1.outputs", "network1", None),
+            ("network1.outputs.vpc_id", "network1", "vpc_id"),
+            ("env_info.outputs.environment", "env_info", "environment"),
+            ("network123.outputs.vpc_id", "network123", "vpc_id"),
+            (
+                "remote_state.outputs.data.nested_value",
+                "remote_state",
+                "data.nested_value",
+            ),
+            (
+                'remote_state.outputs.items["test_key"]',
+                "remote_state",
+                'items["test_key"]',
+            ),
+            (
+                'remote_state.outputs.data["test_item"].id',
+                "remote_state",
+                'data["test_item"].id',
+            ),
+            (
+                "state.outputs.level1.level2.level3.level4",
+                "state",
+                "level1.level2.level3.level4",
+            ),
+        ],
+        ids=[
+            "entire_outputs",
+            "specific_key",
+            "with_underscores",
+            "with_numbers",
+            "nested_dot",
+            "nested_bracket",
+            "nested_mixed",
+            "deeply_nested",
+        ],
+    )
+    def test_valid_references(self, input_ref, expected_state, expected_key):
+        """Test parsing valid remote var references."""
+        state, key = parse_remote_var_reference(input_ref)
+        assert state == expected_state
+        assert key == expected_key
+
+    @pytest.mark.parametrize(
+        "invalid_ref,expected_error",
+        [
+            ("network1.vpc_id", "Invalid remote var reference"),
+            ("", "Invalid remote var reference"),
+            ("network-1.outputs.vpc_id", "State name must contain only"),
+            ("network1.outputs.vpc-id", "Use bracket notation"),
+            (".outputs.vpc_id", "State name must contain only"),
+        ],
+        ids=[
+            "missing_outputs",
+            "empty_string",
+            "special_chars_state",
+            "special_chars_key",
+            "missing_state",
+        ],
+    )
+    def test_invalid_references(self, invalid_ref, expected_error):
+        """Test that invalid references raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_remote_var_reference(invalid_ref)
+        assert expected_error in str(exc_info.value)
+
+
+class TestGenerateTfReference:
+    """Tests for generate_tf_reference() function."""
+
+    @pytest.mark.parametrize(
+        "input_ref,expected_output",
+        [
+            ("network1.outputs", "data.terraform_remote_state.network1.outputs"),
+            (
+                "network1.outputs.vpc_id",
+                "data.terraform_remote_state.network1.outputs.vpc_id",
+            ),
+            (
+                "env_info.outputs.environment",
+                "data.terraform_remote_state.env_info.outputs.environment",
+            ),
+            (
+                "remote_state.outputs.data.nested_value",
+                "data.terraform_remote_state.remote_state.outputs.data.nested_value",
+            ),
+            (
+                'remote_state.outputs.items["test_key"]',
+                'data.terraform_remote_state.remote_state.outputs.items["test_key"]',
+            ),
+            (
+                'remote_state.outputs.data["test_item"].id',
+                'data.terraform_remote_state.remote_state.outputs.data["test_item"].id',
+            ),
+        ],
+        ids=[
+            "entire_outputs",
+            "specific_key",
+            "with_underscores",
+            "nested_dot",
+            "nested_bracket",
+            "nested_mixed",
+        ],
+    )
+    def test_valid_generation(self, input_ref, expected_output):
+        """Test generating valid Terraform references."""
+        assert generate_tf_reference(input_ref) == expected_output
+
+    def test_invalid_format(self):
+        """Test that invalid format raises ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            generate_tf_reference("invalid.reference")
+        assert "Invalid remote var reference" in str(exc_info.value)
+
+
+class TestExtractRemoteStates:
+    """Tests for extract_remote_states() function."""
+
+    @pytest.mark.parametrize(
+        "value,expected_states",
+        [
+            ("network1.outputs.vpc_id", {"network1"}),
+            ("network1.outputs", {"network1"}),
+            ({"k1": "net1.outputs", "k2": "net2.outputs.vpc"}, {"net1", "net2"}),
+            (
+                ["net1.outputs", "net2.outputs.id", "net3.outputs.name"],
+                {"net1", "net2", "net3"},
+            ),
+            ({}, set()),
+            ([], set()),
+        ],
+        ids=[
+            "simple_string",
+            "string_entire_outputs",
+            "dict_single_level",
+            "list",
+            "empty_dict",
+            "empty_list",
+        ],
+    )
+    def test_extract_basic_cases(self, value, expected_states):
+        """Test extracting state names from various structures."""
+        assert extract_remote_states(value) == expected_states
+
+    def test_extract_from_nested_dict(self):
+        """Test extracting state names from nested dict structure."""
+        states = extract_remote_states(
+            {
+                "vpcs": {"platform": "net1.outputs", "payments": "net2.outputs.vpc"},
+                "env": "env_info.outputs.environment",
+            }
+        )
+        assert states == {"net1", "net2", "env_info"}
+
+    def test_extract_from_nested_list_in_dict(self):
+        """Test extracting state names from list nested in dict."""
+        states = extract_remote_states(
+            {
+                "vpc_ids": ["net1.outputs.vpc_id", "net2.outputs.vpc_id"],
+                "env": "env_info.outputs.environment",
+            }
+        )
+        assert states == {"net1", "net2", "env_info"}
+
+    def test_extract_from_dict_in_list(self):
+        """Test extracting state names from dict nested in list."""
+        states = extract_remote_states(
+            [{"name": "net1.outputs.name"}, {"name": "net2.outputs.name"}]
+        )
+        assert states == {"net1", "net2"}
+
+    def test_extract_from_deeply_nested_structure(self):
+        """Test extracting state names from deeply nested structure."""
+        states = extract_remote_states(
+            {
+                "networks": {
+                    "production": {
+                        "primary": "net1.outputs",
+                        "secondary": "net2.outputs",
+                    },
+                    "staging": ["net3.outputs.vpc_id", "net4.outputs.vpc_id"],
+                },
+                "databases": [
+                    {"primary": "db1.outputs.endpoint"},
+                    {"replica": "db2.outputs.endpoint"},
+                ],
+            }
+        )
+        assert states == {"net1", "net2", "net3", "net4", "db1", "db2"}
+
+    def test_extract_duplicate_states(self):
+        """Test that duplicate state names are deduplicated."""
+        states = extract_remote_states(
+            {
+                "vpc_id": "net1.outputs.vpc_id",
+                "subnet_ids": "net1.outputs.subnet_ids",
+                "cidr": "net1.outputs.cidr",
+            }
+        )
+        assert states == {"net1"}
+
+
+class TestParseTfReference:
+    """Tests for parse_tf_reference() function."""
+
+    @pytest.mark.parametrize(
+        "tf_ref,expected_state,expected_key",
+        [
+            ("data.terraform_remote_state.network1.outputs", "network1", None),
+            (
+                "data.terraform_remote_state.network1.outputs.vpc_id",
+                "network1",
+                "vpc_id",
+            ),
+            (
+                "data.terraform_remote_state.env_info.outputs.environment",
+                "env_info",
+                "environment",
+            ),
+            (
+                "data.terraform_remote_state.remote_state.outputs.data.nested_value",
+                "remote_state",
+                "data.nested_value",
+            ),
+            (
+                'data.terraform_remote_state.remote_state.outputs.items["test_key"]',
+                "remote_state",
+                'items["test_key"]',
+            ),
+            (
+                'data.terraform_remote_state.remote_state.outputs.data["test_item"].id',
+                "remote_state",
+                'data["test_item"].id',
+            ),
+        ],
+        ids=[
+            "entire_outputs",
+            "specific_key",
+            "with_underscores",
+            "nested_dot",
+            "nested_bracket",
+            "nested_mixed",
+        ],
+    )
+    def test_valid_parsing(self, tf_ref, expected_state, expected_key):
+        """Test parsing valid Terraform references."""
+        state, key = parse_tf_reference(tf_ref)
+        assert state == expected_state
+        assert key == expected_key
+
+    @pytest.mark.parametrize(
+        "invalid_ref,expected_error",
+        [
+            (
+                "terraform_remote_state.network1.outputs",
+                "Invalid Terraform remote state reference",
+            ),
+            (
+                "data.remote_state.network1.outputs",
+                "Invalid Terraform remote state reference",
+            ),
+            (
+                "data.terraform_remote_state.network1.vpc_id",
+                "Invalid Terraform remote state reference",
+            ),
+            ("", "Invalid Terraform remote state reference"),
+        ],
+        ids=[
+            "missing_data_prefix",
+            "wrong_middle",
+            "missing_outputs",
+            "empty_string",
+        ],
+    )
+    def test_invalid_parsing(self, invalid_ref, expected_error):
+        """Test that invalid references raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_tf_reference(invalid_ref)
+        assert expected_error in str(exc_info.value)
+
+
+class TestValidateRemoteVars:
+    """Tests for validate_remote_vars() function."""
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {"env": "env_info.outputs.environment"},
+            {"vpcs": {"platform": "net1.outputs", "payments": "net2.outputs.vpc"}},
+            {"vpc_ids": ["net1.outputs.vpc_id", "net2.outputs.vpc_id"]},
+            {
+                "networks": {
+                    "production": {
+                        "primary": "net1.outputs",
+                        "secondary": "net2.outputs",
+                    }
+                },
+                "databases": ["db1.outputs.endpoint"],
+            },
+            {},
+        ],
+        ids=[
+            "simple_string",
+            "dict_structure",
+            "list_structure",
+            "nested_structure",
+            "empty_dict",
+        ],
+    )
+    def test_valid_configs(self, config):
+        """Test validating valid remote_vars configurations."""
+        validate_remote_vars(config)  # Should not raise
+
+    @pytest.mark.parametrize(
+        "config,expected_error",
+        [
+            (
+                {"bad": "invalid.reference"},
+                "Invalid remote_vars configuration for key 'bad'",
+            ),
+            (
+                {"vpcs": {"platform": "invalid.reference"}},
+                "Invalid remote_vars configuration for key 'vpcs'",
+            ),
+            ({"items": [123, 456]}, "Unsupported remote_vars value type"),
+            (
+                {"valid": "net1.outputs.vpc", "invalid": "bad.reference"},
+                "Invalid remote_vars configuration for key 'invalid'",
+            ),
+        ],
+        ids=[
+            "invalid_string",
+            "invalid_nested_string",
+            "invalid_type_in_list",
+            "multiple_keys_one_invalid",
+        ],
+    )
+    def test_invalid_configs(self, config, expected_error):
+        """Test that invalid configurations raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            validate_remote_vars(config)
+        assert expected_error in str(exc_info.value)
+
+
+class TestIntegrationScenarios:
+    """Integration tests for common usage scenarios."""
+
+    def test_standard_string_references(self):
+        """Test that standard string references work correctly."""
+        config = {
+            "global_ipv4_blacklist": "env_info.outputs.global_ipv4_blacklist",
+            "vpcs": "env_info.outputs.vpcs",
+            "waf_ip_lists": "env_info.outputs.waf_ip_lists",
+            "environment": "env_info.outputs.environment",
+        }
+
+        # Validate
+        validate_remote_vars(config)
+
+        # Extract states
+        all_states = set()
+        for value in config.values():
+            all_states.update(extract_remote_states(value))
+        assert all_states == {"env_info"}
+
+        # Generate Terraform references
+        for key, value in config.items():
+            tf_ref = generate_tf_reference(value)
+            assert tf_ref.startswith("data.terraform_remote_state.env_info.outputs.")
+
+    def test_new_dict_structure_entire_outputs(self):
+        """Test new dict structure with entire outputs."""
+        config = {
+            "vpcs": {
+                "platform-tools": "network1.outputs",
+                "payments-network": "network2.outputs",
+            }
+        }
+
+        # Validate
+        validate_remote_vars(config)
+
+        # Extract states
+        states = extract_remote_states(config["vpcs"])
+        assert states == {"network1", "network2"}
+
+        # Generate Terraform references
+        for key, value in config["vpcs"].items():
+            tf_ref = generate_tf_reference(value)
+            state, output_key = parse_tf_reference(tf_ref)
+            assert output_key is None  # Entire outputs requested
+
+    def test_new_dict_structure_specific_keys(self):
+        """Test new dict structure with specific output keys."""
+        config = {
+            "vpc_configs": {
+                "platform": "network1.outputs.vpc_config",
+                "payments": "network2.outputs.vpc_config",
+            }
+        }
+
+        # Validate
+        validate_remote_vars(config)
+
+        # Extract states
+        states = extract_remote_states(config["vpc_configs"])
+        assert states == {"network1", "network2"}
+
+        # Generate Terraform references
+        for key, value in config["vpc_configs"].items():
+            tf_ref = generate_tf_reference(value)
+            state, output_key = parse_tf_reference(tf_ref)
+            assert output_key == "vpc_config"
+
+    def test_new_list_structure(self):
+        """Test new list structure."""
+        config = {
+            "all_vpc_ids": [
+                "network1.outputs.vpc_id",
+                "network2.outputs.vpc_id",
+                "network3.outputs.vpc_id",
+            ]
+        }
+
+        # Validate
+        validate_remote_vars(config)
+
+        # Extract states
+        states = extract_remote_states(config["all_vpc_ids"])
+        assert states == {"network1", "network2", "network3"}
+
+        # Generate Terraform references
+        for value in config["all_vpc_ids"]:
+            tf_ref = generate_tf_reference(value)
+            state, output_key = parse_tf_reference(tf_ref)
+            assert output_key == "vpc_id"
+
+    def test_mixed_simple_and_complex(self):
+        """Test config with mix of simple and complex structures."""
+        config = {
+            # Simple (existing)
+            "environment": "env_info.outputs.environment",
+            # Dict with entire outputs
+            "vpcs": {"platform": "network1.outputs", "payments": "network2.outputs"},
+            # List
+            "vpc_ids": ["network1.outputs.vpc_id", "network2.outputs.vpc_id"],
+            # Dict with specific keys
+            "endpoints": {
+                "db_primary": "db1.outputs.endpoint",
+                "db_replica": "db2.outputs.endpoint",
+            },
+        }
+
+        # Validate entire config
+        validate_remote_vars(config)
+
+        # Extract all states
+        all_states = set()
+        for value in config.values():
+            all_states.update(extract_remote_states(value))
+        assert all_states == {"env_info", "network1", "network2", "db1", "db2"}

--- a/tfworker/backends/s3.py
+++ b/tfworker/backends/s3.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Generator
 import boto3.dynamodb
 import botocore
 import botocore.errorfactory
+import botocore.exceptions
 import botocore.paginate
 import click
 
@@ -77,9 +78,27 @@ class S3Backend(BaseBackend):
         self._s3_client: botocore.client.S3 = (
             self._authenticator.backend_session.client("s3")
         )
-        self._ensure_locking_table()
-        self._ensure_backend_bucket()
-        self._bucket_files: list = self._list_bucket_definitions()
+
+        try:
+            self._ensure_locking_table()
+            self._ensure_backend_bucket()
+            self._bucket_files: list = self._list_bucket_definitions()
+        except (
+            botocore.exceptions.TokenRetrievalError,
+            botocore.exceptions.NoCredentialsError,
+            botocore.exceptions.PartialCredentialsError,
+        ) as e:
+            raise BackendError(f"AWS authentication failed: {e}") from e
+        except botocore.exceptions.ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in (
+                "ExpiredToken",
+                "InvalidClientTokenId",
+                "SignatureDoesNotMatch",
+                "AccessDenied",
+            ):
+                raise BackendError(f"AWS authentication failed: {e}") from e
+            raise
 
     @property
     def remotes(self) -> list:

--- a/tfworker/definitions/model.py
+++ b/tfworker/definitions/model.py
@@ -55,9 +55,11 @@ class Definition(BaseModel):
     terraform_vars: Optional[Dict[str, Any]] = Field(
         {}, description="Variables to pass to terraform via a generated .tfvars file."
     )
-    remote_vars: Optional[Dict[str, str]] = Field(
+    remote_vars: Optional[Dict[str, str | Dict | list]] = Field(
         {},
-        description="Variables which are used to generate local references to remote state vars.",
+        description="Variables which are used to generate local references to remote state vars. "
+        "Supports strings (e.g., 'state.outputs.key'), dicts for mapping keys to remote refs, "
+        "and lists of remote refs.",
     )
     squelch_plan_output: bool = False
     squelch_apply_output: bool = False

--- a/tfworker/definitions/prepare.py
+++ b/tfworker/definitions/prepare.py
@@ -95,8 +95,55 @@ class DefinitionPrepare:
             for k, v in definition.get_remote_vars(
                 global_vars=self._app_state.loaded_config.global_vars.remote_vars
             ).items():
-                tflocals.write(f"  {k} = data.terraform_remote_state.{v}\n")
+                # Generate Terraform HCL for the value (handles str/dict/list)
+                tf_value = self._generate_tf_value(v, indent=1)
+                tflocals.write(f"  {k} = {tf_value}\n")
             tflocals.write("}\n\n")
+
+    def _generate_tf_value(self, value: Union[str, Dict, list], indent: int = 0) -> str:
+        """
+        Recursively generate Terraform HCL for a remote_vars value.
+
+        Args:
+            value: The remote_vars value (string ref, dict, or list)
+            indent: Current indentation level
+
+        Returns:
+            Terraform HCL string
+
+        Raises:
+            ValueError: If the value type is unsupported
+        """
+        from tfworker.util.remote_vars import generate_tf_reference
+
+        if isinstance(value, str):
+            # Simple string reference: "state.outputs.key"
+            return generate_tf_reference(value)
+
+        elif isinstance(value, dict):
+            # Dict: {"k1": "state1.outputs", "k2": "state2.outputs.key"}
+            if not value:
+                return "{}"
+            lines = ["{"]
+            for key, val in value.items():
+                nested_value = self._generate_tf_value(val, indent + 1)
+                lines.append(f'{"  " * (indent + 1)}"{key}" = {nested_value}')
+            lines.append(f'{"  " * indent}}}')
+            return "\n".join(lines)
+
+        elif isinstance(value, list):
+            # List: ["state1.outputs", "state2.outputs.key"]
+            if not value:
+                return "[]"
+            lines = ["["]
+            for item in value:
+                nested_value = self._generate_tf_value(item, indent + 1)
+                lines.append(f'{"  " * (indent + 1)}{nested_value},')
+            lines.append(f'{"  " * indent}]')
+            return "\n".join(lines)
+
+        else:
+            raise ValueError(f"Unsupported remote_vars value type: {type(value)}")
 
     def create_worker_tf(self, name: str) -> None:
         """Create remote data sources, and required providers"""
@@ -197,20 +244,21 @@ class DefinitionPrepare:
 
     def _get_remotes(self, name: str) -> list:
         """Get the remote data sources"""
+        from tfworker.util.remote_vars import extract_remote_states
+
         definition = self._app_state.definitions[name]
         log.trace(f"getting remotes for definition {name}")
         if self._app_state.terraform_options.backend_use_all_remotes:
             log.trace(f"using all remotes for definition {name}")
             remotes = self._app_state.backend.remotes
         else:
-            remotes = list(
-                map(
-                    lambda x: x.split(".")[0],
-                    definition.get_remote_vars(
-                        global_vars=self._app_state.loaded_config.global_vars.remote_vars
-                    ).values(),
-                )
-            )
+            # Extract state names from all remote_vars values (recursive)
+            remote_states = set()
+            for value in definition.get_remote_vars(
+                global_vars=self._app_state.loaded_config.global_vars.remote_vars
+            ).values():
+                remote_states.update(extract_remote_states(value))
+            remotes = list(remote_states)
             log.trace(f"using remotes {remotes} for definition {name}")
         return remotes
 

--- a/tfworker/util/hooks.py
+++ b/tfworker/util/hooks.py
@@ -374,6 +374,8 @@ def _populate_environment_with_terraform_remote_vars(
     """
     Populates the environment with Terraform variables.
 
+    Supports nested structures (dicts and lists) in addition to simple references.
+
     Args:
         local_env (Dict[str, str]): The environment variables.
         working_dir (str): The working directory of the Terraform definition.
@@ -386,15 +388,33 @@ def _populate_environment_with_terraform_remote_vars(
     with open(os.path.join(working_dir, WORKER_LOCALS_FILENAME)) as f:
         contents = f.read()
 
-    # I'm sorry. :-)
-    # this regex looks for variables in the form of:
-    # <var_name, ITEM> = data.terraform_remote_state.<the name of a remote definition, STATE>.outputs.<the name of an output, STATE_ITEM>
+    # Create a cache dict to avoid multiple backend calls for the same state
+    state_cache: Dict[str, Dict[str, Any]] = {}
+
+    # Try parsing with HCL2 for nested structures
+    try:
+        parsed = hcl2.loads(contents)
+        if "locals" in parsed and parsed["locals"]:
+            locals_block = parsed["locals"][0]
+            for var_name, var_value in locals_block.items():
+                resolved_value = _resolve_terraform_value(
+                    var_value, backend, state_cache
+                )
+                _set_hook_env_var(
+                    local_env,
+                    TFHookVarType.REMOTE,
+                    var_name,
+                    resolved_value,
+                    b64_encode,
+                )
+            return
+    except Exception as e:
+        log.debug(f"HCL2 parsing failed, falling back to regex: {e}")
+
+    # Fallback to legacy regex-based parsing for simple single-line references
     r = re.compile(
         r"\s*(?P<item>\w+)\s*\=.+data\.terraform_remote_state\.(?P<state>\w+)\.outputs\.(?P<state_item>\w+)\s*"
     )
-
-    # Create a cache dict to avoid multiple backend calls for the same state
-    state_cache: Dict[str, Dict[str, Any]] = {}
 
     for line in contents.splitlines():
         m = r.match(line)
@@ -413,22 +433,86 @@ def _populate_environment_with_terraform_remote_vars(
             )
 
             # Parse the Terraform output JSON to extract just the value field
-            # Terraform output format is: {"value": <actual_value>, "type": <type>, "sensitive": <bool>}
             try:
                 state_output = json.loads(state_value_json)
-                # Extract just the value field from the Terraform output structure
                 if isinstance(state_output, dict) and "value" in state_output:
                     state_value = state_output["value"]
                 else:
-                    # Fallback to the raw value if it's not in the expected format
                     state_value = state_value_json
             except (json.JSONDecodeError, TypeError):
-                # If parsing fails, use the raw value
                 state_value = state_value_json
 
             _set_hook_env_var(
                 local_env, TFHookVarType.REMOTE, item, state_value, b64_encode
             )
+
+
+def _resolve_terraform_value(
+    value: Any,
+    backend: "BaseBackend",
+    state_cache: Dict[str, Dict[str, Any]],
+) -> Any:
+    """
+    Recursively resolve Terraform remote state references to actual values.
+
+    Handles:
+    - Simple strings with terraform_remote_state references
+    - Nested dicts
+    - Lists
+    - Literal values
+
+    Args:
+        value: The value to resolve (str, dict, list, or literal)
+        backend: The backend instance to fetch state from
+        state_cache: Cache of already-fetched state data
+
+    Returns:
+        Resolved value with terraform_remote_state references replaced by actual values
+    """
+    from tfworker.util.remote_vars import parse_tf_reference
+
+    if isinstance(value, str):
+        # Check if it's a terraform_remote_state reference
+        if "data.terraform_remote_state" in value:
+            try:
+                # Extract state and output_key from the reference
+                state, output_key = parse_tf_reference(value)
+
+                # Get the state data
+                state_data = _get_or_fetch_state(state, backend, state_cache)
+                outputs = state_data.get("outputs", {})
+
+                if output_key is None:
+                    # Return entire outputs dict (all output values)
+                    return {k: v.get("value") for k, v in outputs.items()}
+                else:
+                    # Return specific output value
+                    if output_key not in outputs:
+                        raise HookError(
+                            f"Output '{output_key}' not found in state '{state}'"
+                        )
+                    return outputs[output_key].get("value")
+            except (ValueError, KeyError) as e:
+                log.warning(f"Failed to parse terraform reference '{value}': {e}")
+                return value
+        else:
+            # Plain string, return as-is
+            return value
+
+    elif isinstance(value, dict):
+        # Recursively resolve dict values
+        return {
+            k: _resolve_terraform_value(v, backend, state_cache)
+            for k, v in value.items()
+        }
+
+    elif isinstance(value, list):
+        # Recursively resolve list items
+        return [_resolve_terraform_value(item, backend, state_cache) for item in value]
+
+    else:
+        # Literal value (int, bool, etc.), return as-is
+        return value
 
 
 def _populate_environment_with_extra_vars(
@@ -483,7 +567,9 @@ def _set_hook_env_var(
 
         # Base64-encode and store as a string to satisfy env type requirements
         encoded = base64.b64encode(raw_bytes).decode()
-        local_env[f"{var_type}_{key.upper()}"] = encoded
+        var_name = f"{var_type}_{key.upper()}"
+        local_env[var_name] = encoded
+        _check_env_var_size(var_name, encoded, b64_encode=True)
         return
 
     # For non-base64 values, ensure we end up with a string and shell-escape it
@@ -504,7 +590,61 @@ def _set_hook_env_var(
     # Use shlex.quote to safely escape values for shell consumption by hooks
     value_escaped = shlex.quote(value_str)
 
-    local_env[f"{var_type}_{key.upper()}"] = value_escaped
+    var_name = f"{var_type}_{key.upper()}"
+    local_env[var_name] = value_escaped
+    _check_env_var_size(var_name, value_escaped, b64_encode=False)
+
+
+def _check_env_var_size(
+    var_name: str, var_value: str, b64_encode: bool = False
+) -> None:
+    """
+    Check environment variable size and warn if approaching or exceeding shell limits.
+
+    Different shells have different limits for environment variable sizes:
+    - bash: typically 128 KB (131072 bytes)
+    - zsh: typically 1 MB (1048576 bytes)
+    - sh/dash: typically 64 KB (65536 bytes)
+
+    Args:
+        var_name: The environment variable name
+        var_value: The environment variable value
+        b64_encode: Whether the value is base64 encoded
+    """
+    # Shell-specific limits (in bytes)
+    SHELL_LIMITS = {
+        "bash": 131072,  # 128 KB
+        "zsh": 1048576,  # 1 MB
+        "sh": 65536,  # 64 KB
+        "dash": 65536,  # 64 KB
+    }
+
+    var_size = len(var_value.encode("utf-8"))
+
+    # Determine the current shell from SHELL environment variable
+    current_shell = os.environ.get("SHELL", "").split("/")[-1] or "sh"
+    limit = SHELL_LIMITS.get(
+        current_shell, SHELL_LIMITS["sh"]
+    )  # Default to sh (most conservative)
+
+    # Calculate warning threshold (80% of limit)
+    warning_threshold = int(limit * 0.8)
+
+    if var_size > limit:
+        encoding_note = " (base64 encoded)" if b64_encode else ""
+        log.warn(
+            f"Environment variable {var_name} is {var_size:,} bytes{encoding_note}, "
+            f"which exceeds the typical {current_shell} limit of {limit:,} bytes. "
+            f"This may cause issues in hook scripts. "
+            f"Consider using --b64-encode-hook-values or restructuring the data."
+        )
+    elif var_size > warning_threshold:
+        encoding_note = " (base64 encoded)" if b64_encode else ""
+        log.info(
+            f"Environment variable {var_name} is {var_size:,} bytes{encoding_note}, "
+            f"approaching the {current_shell} limit of {limit:,} bytes "
+            f"({var_size * 100 // limit}% of limit)."
+        )
 
 
 def _execute_hook_script(

--- a/tfworker/util/remote_vars.py
+++ b/tfworker/util/remote_vars.py
@@ -1,0 +1,291 @@
+"""Utilities for parsing and processing remote_vars configurations."""
+
+import re
+from typing import Any, Dict, List, Set, Tuple, Union
+
+# Type alias for remote_vars values
+RemoteVarValue = Union[str, Dict[str, Any], List[Any]]
+
+
+def parse_remote_var_reference(value: str) -> Tuple[str, str | None]:
+    """
+    Parse a remote var reference into state name and optional output key path.
+
+    Supports multiple formats:
+    - "state.outputs" -> entire outputs dict from state
+    - "state.outputs.key" -> specific output key from state
+    - "state.outputs.key.nested" -> nested key with dot notation
+    - "state.outputs.key["index"]" -> key with bracket notation
+    - "state.outputs.key.nested["index"]" -> mixed notation
+
+    Args:
+        value: Remote var reference string (e.g., "network1.outputs.vpc_id")
+
+    Returns:
+        Tuple of (state_name, output_key_path_or_None)
+        - If output_key_path is None, the entire outputs dict is requested
+        - If output_key_path is present, it's the path to the output (may include nested keys)
+
+    Raises:
+        ValueError: If the reference format is invalid
+
+    Examples:
+        >>> parse_remote_var_reference("network1.outputs")
+        ('network1', None)
+
+        >>> parse_remote_var_reference("network1.outputs.vpc_id")
+        ('network1', 'vpc_id')
+
+        >>> parse_remote_var_reference("network1.outputs.data.nested_key")
+        ('network1', 'data.nested_key')
+
+        >>> parse_remote_var_reference("network1.outputs.items[\"test_key\"]")
+        ('network1', 'items["test_key"]')
+    """
+    # Split on '.outputs' to separate state from key path
+    if ".outputs" not in value:
+        raise ValueError(
+            f"Invalid remote var reference: '{value}'. "
+            f"Expected format: 'state.outputs[.key.path]' or 'state.outputs[\"key\"]'"
+        )
+
+    parts = value.split(".outputs", 1)
+    state = parts[0]
+    key_path = parts[1] if len(parts) > 1 else ""
+
+    # Validate state name (must be word characters only)
+    if not re.match(r"^\w+$", state):
+        raise ValueError(
+            f"Invalid remote var reference: '{value}'. "
+            f"State name must contain only alphanumeric characters and underscores."
+        )
+
+    # If there's a key path, validate it starts with . or [
+    if key_path:
+        if not key_path.startswith(".") and not key_path.startswith("["):
+            raise ValueError(
+                f"Invalid remote var reference: '{value}'. "
+                f"Key path after 'outputs' must start with '.' or '[', got: '{key_path}'"
+            )
+
+        # If using pure dot notation (no brackets), validate each segment
+        if "[" not in key_path:
+            # Remove leading '.'
+            clean_path = key_path[1:] if key_path.startswith(".") else key_path
+            # Split on dots and validate each segment
+            segments = clean_path.split(".")
+            for segment in segments:
+                if segment and not re.match(r"^\w+$", segment):
+                    raise ValueError(
+                        f"Invalid remote var reference: '{value}'. "
+                        f"When using dot notation, each key segment must contain only "
+                        f"alphanumeric characters and underscores. Invalid segment: '{segment}'. "
+                        f"Use bracket notation for keys with special characters: 'state.outputs[\"{segment}\"]'"
+                    )
+
+        # Remove leading '.' for consistency
+        if key_path.startswith("."):
+            key_path = key_path[1:]
+        return state, key_path
+    else:
+        return state, None
+
+
+def generate_tf_reference(value: str) -> str:
+    """
+    Convert a remote var reference to Terraform HCL data source syntax.
+
+    Args:
+        value: Remote var reference string (e.g., "network1.outputs.vpc_id")
+
+    Returns:
+        Terraform HCL reference string
+
+    Raises:
+        ValueError: If the reference format is invalid
+
+    Examples:
+        >>> generate_tf_reference("network1.outputs")
+        'data.terraform_remote_state.network1.outputs'
+
+        >>> generate_tf_reference("network1.outputs.vpc_id")
+        'data.terraform_remote_state.network1.outputs.vpc_id'
+
+        >>> generate_tf_reference("network1.outputs.data.nested_key")
+        'data.terraform_remote_state.network1.outputs.data.nested_key'
+
+        >>> generate_tf_reference("network1.outputs.items[\"test_key\"]")
+        'data.terraform_remote_state.network1.outputs.items["test_key"]'
+    """
+    state, key_path = parse_remote_var_reference(value)
+    base_ref = f"data.terraform_remote_state.{state}.outputs"
+    if key_path:
+        # If key_path starts with '[', don't add a dot
+        if key_path.startswith("["):
+            return f"{base_ref}{key_path}"
+        else:
+            return f"{base_ref}.{key_path}"
+    return base_ref
+
+
+def extract_remote_states(value: RemoteVarValue) -> Set[str]:
+    """
+    Recursively extract all remote state names from a remote_vars value.
+
+    Supports strings, dicts, and lists to handle complex nested structures.
+
+    Args:
+        value: A remote_vars value (string, dict, or list)
+
+    Returns:
+        Set of unique state names referenced in the value
+
+    Examples:
+        >>> extract_remote_states("network1.outputs.vpc_id")
+        {'network1'}
+
+        >>> extract_remote_states({"k1": "net1.outputs", "k2": "net2.outputs.vpc"})
+        {'net1', 'net2'}
+
+        >>> extract_remote_states(["net1.outputs", "net2.outputs.id"])
+        {'net1', 'net2'}
+
+        >>> extract_remote_states({
+        ...     "vpcs": {
+        ...         "platform": "net1.outputs",
+        ...         "payments": "net2.outputs.vpc"
+        ...     },
+        ...     "env": "env_info.outputs.environment"
+        ... })
+        {'net1', 'net2', 'env_info'}
+    """
+    states = set()
+
+    if isinstance(value, str):
+        # Simple string reference
+        state, _ = parse_remote_var_reference(value)
+        states.add(state)
+    elif isinstance(value, dict):
+        # Dict: recursively process all values
+        for v in value.values():
+            states.update(extract_remote_states(v))
+    elif isinstance(value, list):
+        # List: recursively process all items
+        for item in value:
+            states.update(extract_remote_states(item))
+
+    return states
+
+
+def parse_tf_reference(tf_ref: str) -> Tuple[str, str | None]:
+    """
+    Parse a Terraform remote state reference into state name and optional output key path.
+
+    This is the inverse of generate_tf_reference() - it parses Terraform HCL
+    references back into their components.
+
+    Args:
+        tf_ref: Terraform HCL reference (e.g., "data.terraform_remote_state.net1.outputs.vpc_id")
+
+    Returns:
+        Tuple of (state_name, output_key_path_or_None)
+
+    Raises:
+        ValueError: If the reference format is invalid
+
+    Examples:
+        >>> parse_tf_reference("data.terraform_remote_state.network1.outputs")
+        ('network1', None)
+
+        >>> parse_tf_reference("data.terraform_remote_state.network1.outputs.vpc_id")
+        ('network1', 'vpc_id')
+
+        >>> parse_tf_reference("data.terraform_remote_state.network1.outputs.data.nested_key")
+        ('network1', 'data.nested_key')
+
+        >>> parse_tf_reference("data.terraform_remote_state.network1.outputs.items[\"test_key\"]")
+        ('network1', 'items["test_key"]')
+    """
+    # Split on '.outputs' to separate the prefix from the key path
+    prefix = "data.terraform_remote_state."
+    if not tf_ref.startswith(prefix):
+        raise ValueError(
+            f"Invalid Terraform remote state reference: '{tf_ref}'. "
+            f"Expected format: 'data.terraform_remote_state.state.outputs[.key.path]'"
+        )
+
+    remainder = tf_ref[len(prefix) :]
+    if ".outputs" not in remainder:
+        raise ValueError(
+            f"Invalid Terraform remote state reference: '{tf_ref}'. "
+            f"Expected format: 'data.terraform_remote_state.state.outputs[.key.path]'"
+        )
+
+    parts = remainder.split(".outputs", 1)
+    state = parts[0]
+    key_path = parts[1] if len(parts) > 1 else ""
+
+    # Validate state name
+    if not re.match(r"^\w+$", state):
+        raise ValueError(
+            f"Invalid Terraform remote state reference: '{tf_ref}'. "
+            f"State name must contain only alphanumeric characters and underscores."
+        )
+
+    # Process key path
+    if key_path:
+        # Remove leading '.' if present
+        if key_path.startswith("."):
+            key_path = key_path[1:]
+        return state, key_path if key_path else None
+    else:
+        return state, None
+
+
+def validate_remote_vars(remote_vars: Dict[str, RemoteVarValue]) -> None:
+    """
+    Validate a remote_vars configuration dictionary.
+
+    Checks that all string references are properly formatted and recursively
+    validates nested structures.
+
+    Args:
+        remote_vars: Dictionary of remote variable configurations
+
+    Raises:
+        ValueError: If any reference is invalid
+
+    Examples:
+        >>> validate_remote_vars({"env": "env_info.outputs.environment"})
+        # No exception - valid
+
+        >>> validate_remote_vars({"bad": "invalid reference"})
+        Traceback (most recent call last):
+        ...
+        ValueError: Invalid remote var reference...
+    """
+    for key, value in remote_vars.items():
+        try:
+            _validate_value(value)
+        except ValueError as e:
+            raise ValueError(f"Invalid remote_vars configuration for key '{key}': {e}")
+
+
+def _validate_value(value: RemoteVarValue) -> None:
+    """Recursively validate a remote_vars value."""
+    if isinstance(value, str):
+        # Validate string reference format
+        parse_remote_var_reference(value)
+    elif isinstance(value, dict):
+        # Recursively validate dict values
+        for v in value.values():
+            _validate_value(v)
+    elif isinstance(value, list):
+        # Recursively validate list items
+        for item in value:
+            _validate_value(item)
+    else:
+        raise ValueError(
+            f"Unsupported remote_vars value type: {type(value).__name__}. "
+            f"Expected str, dict, or list."
+        )


### PR DESCRIPTION
Add support for nested structures (dicts/lists) in remote_vars configuration, enabling more flexible Terraform remote state references.

Key changes:
- New tfworker/util/remote_vars.py module for parsing/validation
- Support nested keys: state.outputs.key.nested["item"]
- Generate proper HCL for dict/list structures in definitions
- Recursively resolve nested remote state values in hooks
- Add HCL2 parsing with regex fallback for backwards compatibility
- Check environment variable sizes and warn about shell limits

Additional improvements:
- Better AWS authentication error handling in S3 backend (TokenRetrievalError, NoCredentialsError, PartialCredentialsError)
- Comprehensive test coverage (126 tests, parameterized for maintainability)

This allows configurations like:
```yaml
  remote_vars:
    kubernetes_clusters:
      prod: clusters.outputs.items["prod-cluster"]
    vpcs:
      platform: network.outputs
```