### PR TITLE
POPS-3391: Add datadog change event handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coverage.xml
 reports/*
 plans*
 docs/superpowers/**
+**/.DS_Store
 
 # Snyk Security Extension - AI Rules (auto-generated)
 .github/instructions/snyk_rules.instructions.md

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,4 @@
 [settings]
-known_third_party = atlassian,boto3,botocore,click,google,hcl2,jinja2,lark,mergedeep,moto,openai,packaging,pydantic,pydantic_core,pydantic_settings,pytest,slack_sdk,yaml
+known_third_party = atlassian,boto3,botocore,click,google,hcl2,jinja2,lark,mergedeep,moto,openai,packaging,pydantic,pydantic_core,pydantic_settings,pytest,slack_sdk,urllib3,yaml
 profile = black
 skip = ["*/__init__.py"]

--- a/tests/handlers/test_datadog_handler.py
+++ b/tests/handlers/test_datadog_handler.py
@@ -1,4 +1,3 @@
-import json
 import os
 from unittest.mock import MagicMock, patch
 
@@ -389,7 +388,7 @@ class TestDatadogExecute:
         assert args[1].endswith("/api/v2/events")
         assert kwargs["headers"]["DD-API-KEY"] == "placeholder-api-key"
         assert kwargs["headers"]["DD-APP-KEY"] == "placeholder-app-key"
-        assert json.loads(kwargs["body"].decode()) == {"data": {"x": 1}}
+        assert kwargs["json"] == {"data": {"x": 1}}
 
 
 class TestDatadogPostErrors:

--- a/tests/handlers/test_datadog_handler.py
+++ b/tests/handlers/test_datadog_handler.py
@@ -152,6 +152,9 @@ class TestDatadogBuildPayload:
     def _defn(self, name="vpc"):
         return Definition(name=name, path="/tmp")
 
+    def _result(self):
+        return TerraformResult(0, b"ok", b"")
+
     def _git_info(self, **overrides):
         info = {
             "branch": "main",
@@ -171,28 +174,44 @@ class TestDatadogBuildPayload:
     def test_category_is_change(self):
         h = self._make_handler()
         p = h._build_payload(
-            TerraformAction.APPLY, self._defn(), "prod-use1", self._git_info()
+            TerraformAction.APPLY,
+            self._defn(),
+            "prod-use1",
+            self._result(),
+            self._git_info(),
         )
         assert p["data"]["attributes"]["category"] == "change"
 
     def test_type_is_event(self):
         h = self._make_handler()
         p = h._build_payload(
-            TerraformAction.APPLY, self._defn(), "prod-use1", self._git_info()
+            TerraformAction.APPLY,
+            self._defn(),
+            "prod-use1",
+            self._result(),
+            self._git_info(),
         )
         assert p["data"]["type"] == "event"
 
     def test_title_includes_action_deployment_and_definition(self):
         h = self._make_handler()
         p = h._build_payload(
-            TerraformAction.APPLY, self._defn(), "prod-use1", self._git_info()
+            TerraformAction.APPLY,
+            self._defn(),
+            "prod-use1",
+            self._result(),
+            self._git_info(),
         )
         assert p["data"]["attributes"]["title"] == "Terraform apply of prod-use1/vpc"
 
     def test_author_uses_email(self):
         h = self._make_handler()
         p = h._build_payload(
-            TerraformAction.APPLY, self._defn(), "prod-use1", self._git_info()
+            TerraformAction.APPLY,
+            self._defn(),
+            "prod-use1",
+            self._result(),
+            self._git_info(),
         )
         assert self._attrs(p)["author"] == {"type": "user", "name": "jane@x.com"}
 
@@ -202,6 +221,7 @@ class TestDatadogBuildPayload:
             TerraformAction.APPLY,
             self._defn(),
             "prod-use1",
+            self._result(),
             self._git_info(author_email="", author_name="Jane Doe"),
         )
         assert self._attrs(p)["author"]["name"] == "Jane Doe"
@@ -210,6 +230,7 @@ class TestDatadogBuildPayload:
             TerraformAction.APPLY,
             self._defn(),
             "prod-use1",
+            self._result(),
             self._git_info(author_email="", author_name=""),
         )
         assert self._attrs(p2)["author"]["name"] == "unknown"
@@ -217,7 +238,11 @@ class TestDatadogBuildPayload:
     def test_changed_resource_is_configuration_named_after_definition(self):
         h = self._make_handler()
         p = h._build_payload(
-            TerraformAction.APPLY, self._defn(), "prod-use1", self._git_info()
+            TerraformAction.APPLY,
+            self._defn(),
+            "prod-use1",
+            self._result(),
+            self._git_info(),
         )
         cr = self._attrs(p)["changed_resource"]
         assert cr == {"type": "configuration", "name": "vpc"}
@@ -228,6 +253,7 @@ class TestDatadogBuildPayload:
             TerraformAction.APPLY,
             self._defn("my_service"),
             "prod-use1",
+            self._result(),
             self._git_info(),
         )
         impacted = self._attrs(p)["impacted_resources"]
@@ -236,7 +262,11 @@ class TestDatadogBuildPayload:
     def test_tags_include_context(self):
         h = self._make_handler()
         p = h._build_payload(
-            TerraformAction.DESTROY, self._defn(), "prod-use1", self._git_info()
+            TerraformAction.DESTROY,
+            self._defn(),
+            "prod-use1",
+            self._result(),
+            self._git_info(),
         )
         tags = p["data"]["attributes"]["tags"]
         assert "env:use1" in tags
@@ -251,6 +281,7 @@ class TestDatadogBuildPayload:
             TerraformAction.APPLY,
             self._defn(),
             "prod-use1",
+            self._result(),
             self._git_info(branch="", short_commit=""),
         )
         tags = p["data"]["attributes"]["tags"]
@@ -263,6 +294,7 @@ class TestDatadogBuildPayload:
             TerraformAction.APPLY,
             self._defn(),
             "prod-use1",
+            self._result(),
             self._git_info(branch="", subject=""),
         )
         meta = self._attrs(p)["change_metadata"]
@@ -277,7 +309,11 @@ class TestDatadogBuildPayload:
     def test_change_metadata_includes_definition_dump(self):
         h = self._make_handler()
         p = h._build_payload(
-            TerraformAction.APPLY, self._defn(), "prod-use1", self._git_info()
+            TerraformAction.APPLY,
+            self._defn(),
+            "prod-use1",
+            self._result(),
+            self._git_info(),
         )
         meta = self._attrs(p)["change_metadata"]
         assert meta["definition"]["name"] == "vpc"

--- a/tests/handlers/test_datadog_handler.py
+++ b/tests/handlers/test_datadog_handler.py
@@ -462,6 +462,70 @@ class TestDatadogPostErrors:
         warn.assert_not_called()
 
 
+class TestDatadogIsReady:
+    """is_ready() validates the API key against Datadog once, then caches the
+    result. Any failure warns and reports not-ready so a Datadog problem never
+    aborts a terraform run."""
+
+    def _make_handler(self):
+        from tfworker.handlers.datadog import DatadogConfig, DatadogHandler
+
+        h = DatadogHandler(DatadogConfig(**_RAW_KEYS))
+        h._http = MagicMock()
+        return h
+
+    def test_valid_credentials_ready(self):
+        h = self._make_handler()
+        h._http.request.return_value = MagicMock(status=200, data=b'{"valid": true}')
+        assert h.is_ready() is True
+
+    def test_validate_uses_api_key_header_and_url(self):
+        h = self._make_handler()
+        h._http.request.return_value = MagicMock(status=200, data=b'{"valid": true}')
+        h.is_ready()
+        args, kwargs = h._http.request.call_args
+        assert args[0] == "GET"
+        assert args[1].endswith("/api/v1/validate")
+        assert kwargs["headers"]["DD-API-KEY"] == "placeholder-api-key"
+
+    def test_invalid_flag_not_ready_and_warns(self):
+        h = self._make_handler()
+        h._http.request.return_value = MagicMock(status=200, data=b'{"valid": false}')
+        with patch("tfworker.handlers.datadog.log.warn") as warn:
+            assert h.is_ready() is False
+        warn.assert_called_once()
+
+    def test_non_200_not_ready_and_warns(self):
+        h = self._make_handler()
+        h._http.request.return_value = MagicMock(status=403, data=b"Forbidden")
+        with patch("tfworker.handlers.datadog.log.warn") as warn:
+            assert h.is_ready() is False
+        warn.assert_called_once()
+        assert "403" in warn.call_args.args[0]
+
+    def test_request_exception_not_ready_and_warns(self):
+        h = self._make_handler()
+        h._http.request.side_effect = Exception("network down")
+        with patch("tfworker.handlers.datadog.log.warn") as warn:
+            assert h.is_ready() is False
+        warn.assert_called_once()
+        assert "network down" in warn.call_args.args[0]
+
+    def test_success_result_is_cached(self):
+        h = self._make_handler()
+        h._http.request.return_value = MagicMock(status=200, data=b'{"valid": true}')
+        assert h.is_ready() is True
+        assert h.is_ready() is True
+        h._http.request.assert_called_once()
+
+    def test_failure_result_is_cached(self):
+        h = self._make_handler()
+        h._http.request.return_value = MagicMock(status=403, data=b"Forbidden")
+        assert h.is_ready() is False
+        assert h.is_ready() is False
+        h._http.request.assert_called_once()
+
+
 class TestDatadogRegistry:
     def test_registered_as_datadog(self):
         import tfworker.handlers.datadog  # noqa: F401

--- a/tests/handlers/test_datadog_handler.py
+++ b/tests/handlers/test_datadog_handler.py
@@ -1,0 +1,450 @@
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tfworker.commands.terraform import TerraformResult
+from tfworker.custom_types.terraform import TerraformAction, TerraformStage
+from tfworker.definitions.model import Definition
+
+# Both credentials are required by the config validator. Tests that don't care
+# about credential resolution provide raw values for both.
+_RAW_KEYS = {"api_key": "placeholder-api-key", "app_key": "placeholder-app-key"}
+
+
+class TestDatadogConfig:
+    def test_api_key_raw_value(self):
+        from tfworker.handlers.datadog import DatadogConfig
+
+        cfg = DatadogConfig(api_key="dd-raw", app_key="app-raw")
+        assert cfg.resolved_api_key == "dd-raw"
+
+    def test_app_key_raw_value(self):
+        from tfworker.handlers.datadog import DatadogConfig
+
+        cfg = DatadogConfig(api_key="dd-raw", app_key="app-raw")
+        assert cfg.resolved_app_key == "app-raw"
+
+    def test_keys_from_default_env_vars(self):
+        from tfworker.handlers.datadog import DatadogConfig
+
+        with patch.dict(
+            os.environ,
+            {"DD_API_KEY": "dd-from-env", "DD_APP_KEY": "app-from-env"},
+            clear=True,
+        ):
+            cfg = DatadogConfig()
+            assert cfg.resolved_api_key == "dd-from-env"
+            assert cfg.resolved_app_key == "app-from-env"
+
+    def test_keys_from_custom_env_vars(self):
+        from tfworker.handlers.datadog import DatadogConfig
+
+        with patch.dict(
+            os.environ,
+            {"MY_DD_KEY": "dd-custom", "MY_DD_APP_KEY": "app-custom"},
+            clear=True,
+        ):
+            cfg = DatadogConfig(api_key_env="MY_DD_KEY", app_key_env="MY_DD_APP_KEY")
+            assert cfg.resolved_api_key == "dd-custom"
+            assert cfg.resolved_app_key == "app-custom"
+
+    def test_raw_key_takes_precedence_over_env(self):
+        from tfworker.handlers.datadog import DatadogConfig
+
+        with patch.dict(
+            os.environ,
+            {"DD_API_KEY": "dd-env", "DD_APP_KEY": "app-env"},
+            clear=True,
+        ):
+            cfg = DatadogConfig(api_key="dd-raw", app_key="app-raw")
+            assert cfg.resolved_api_key == "dd-raw"
+            assert cfg.resolved_app_key == "app-raw"
+
+    def test_missing_api_key_raises(self):
+        from tfworker.handlers.datadog import DatadogConfig
+
+        # Only an app key is available; the api key cannot be resolved.
+        with patch.dict(os.environ, {"DD_APP_KEY": "app-env"}, clear=True):
+            with pytest.raises(ValueError):
+                DatadogConfig()
+
+    def test_missing_app_key_raises(self):
+        from tfworker.handlers.datadog import DatadogConfig
+
+        # Only an api key is available; the app key cannot be resolved.
+        with patch.dict(os.environ, {"DD_API_KEY": "dd-env"}, clear=True):
+            with pytest.raises(ValueError):
+                DatadogConfig()
+
+    def test_keys_not_exposed_in_repr(self):
+        from tfworker.handlers.datadog import DatadogConfig
+
+        cfg = DatadogConfig(api_key="dd-super-secret", app_key="app-super-secret")
+        assert "dd-super-secret" not in repr(cfg)
+        assert "app-super-secret" not in repr(cfg)
+
+    def test_defaults(self):
+        from tfworker.handlers.datadog import DatadogConfig
+
+        cfg = DatadogConfig(**_RAW_KEYS)
+        assert cfg.api_key_env == "DD_API_KEY"
+        assert cfg.app_key_env == "DD_APP_KEY"
+
+    def test_events_url(self):
+        from tfworker.handlers.datadog import DatadogConfig
+
+        cfg = DatadogConfig(**_RAW_KEYS)
+        assert cfg.events_url == (
+            "https://event-management-intake.datadoghq.com/api/v2/events"
+        )
+
+
+class TestDatadogGitInfo:
+    def _make_handler(self):
+        from tfworker.handlers.datadog import DatadogConfig, DatadogHandler
+
+        return DatadogHandler(DatadogConfig(**_RAW_KEYS))
+
+    def test_git_fields_collected_from_cli(self):
+        h = self._make_handler()
+        # _resolve_git_info calls _git first for the branch (rev-parse), then for
+        # each of commit, short_commit, author_name, author_email, subject (in
+        # order, via git log --format).
+        outputs = ["br", "fullsha", "shortsha", "Jane Doe", "jane@x.com", "fix it"]
+        with patch.object(h, "_git", side_effect=outputs):
+            info = h._resolve_git_info("/somedir")
+        assert info["branch"] == "br"
+        assert info["commit"] == "fullsha"
+        assert info["short_commit"] == "shortsha"
+        assert info["author_name"] == "Jane Doe"
+        assert info["author_email"] == "jane@x.com"
+        assert info["subject"] == "fix it"
+
+    def test_git_info_defaults_to_empty_strings(self):
+        h = self._make_handler()
+        # When every git invocation fails, all fields fall back to "" so a
+        # missing git context never aborts the run.
+        with patch.object(h, "_git", return_value=""):
+            info = h._resolve_git_info("/somedir")
+        assert info == {
+            "branch": "",
+            "commit": "",
+            "short_commit": "",
+            "author_name": "",
+            "author_email": "",
+            "subject": "",
+        }
+
+    def test_git_returns_empty_on_failure(self):
+        from tfworker.handlers.datadog import DatadogHandler
+
+        with patch("subprocess.check_output", side_effect=Exception("no git")):
+            assert DatadogHandler._git("/tmp", "log") == ""
+
+
+class TestDatadogBuildPayload:
+    def _make_handler(self):
+        from tfworker.handlers.datadog import DatadogConfig, DatadogHandler
+
+        return DatadogHandler(DatadogConfig(**_RAW_KEYS))
+
+    def _defn(self, name="vpc"):
+        return Definition(name=name, path="/tmp")
+
+    def _git_info(self, **overrides):
+        info = {
+            "branch": "main",
+            "commit": "abc123def456",
+            "short_commit": "abc123d",
+            "author_name": "Jane Doe",
+            "author_email": "jane@x.com",
+            "subject": "fix vpc",
+        }
+        info.update(overrides)
+        return info
+
+    def _attrs(self, payload):
+        """The inner attributes block holding the change-event details."""
+        return payload["data"]["attributes"]["attributes"]
+
+    def test_category_is_change(self):
+        h = self._make_handler()
+        p = h._build_payload(
+            TerraformAction.APPLY, self._defn(), "prod-use1", self._git_info()
+        )
+        assert p["data"]["attributes"]["category"] == "change"
+
+    def test_type_is_event(self):
+        h = self._make_handler()
+        p = h._build_payload(
+            TerraformAction.APPLY, self._defn(), "prod-use1", self._git_info()
+        )
+        assert p["data"]["type"] == "event"
+
+    def test_title_includes_action_deployment_and_definition(self):
+        h = self._make_handler()
+        p = h._build_payload(
+            TerraformAction.APPLY, self._defn(), "prod-use1", self._git_info()
+        )
+        assert p["data"]["attributes"]["title"] == "Terraform apply of prod-use1/vpc"
+
+    def test_author_uses_email(self):
+        h = self._make_handler()
+        p = h._build_payload(
+            TerraformAction.APPLY, self._defn(), "prod-use1", self._git_info()
+        )
+        assert self._attrs(p)["author"] == {"type": "user", "name": "jane@x.com"}
+
+    def test_author_falls_back_to_name_then_unknown(self):
+        h = self._make_handler()
+        p = h._build_payload(
+            TerraformAction.APPLY,
+            self._defn(),
+            "prod-use1",
+            self._git_info(author_email="", author_name="Jane Doe"),
+        )
+        assert self._attrs(p)["author"]["name"] == "Jane Doe"
+
+        p2 = h._build_payload(
+            TerraformAction.APPLY,
+            self._defn(),
+            "prod-use1",
+            self._git_info(author_email="", author_name=""),
+        )
+        assert self._attrs(p2)["author"]["name"] == "unknown"
+
+    def test_changed_resource_is_configuration_named_after_definition(self):
+        h = self._make_handler()
+        p = h._build_payload(
+            TerraformAction.APPLY, self._defn(), "prod-use1", self._git_info()
+        )
+        cr = self._attrs(p)["changed_resource"]
+        assert cr == {"type": "configuration", "name": "vpc"}
+
+    def test_impacted_resource_name_uses_hyphens(self):
+        h = self._make_handler()
+        p = h._build_payload(
+            TerraformAction.APPLY,
+            self._defn("my_service"),
+            "prod-use1",
+            self._git_info(),
+        )
+        impacted = self._attrs(p)["impacted_resources"]
+        assert impacted == [{"type": "service", "name": "my-service"}]
+
+    def test_tags_include_context(self):
+        h = self._make_handler()
+        p = h._build_payload(
+            TerraformAction.DESTROY, self._defn(), "prod-use1", self._git_info()
+        )
+        tags = p["data"]["attributes"]["tags"]
+        assert "env:use1" in tags
+        assert "definition:vpc" in tags
+        assert "service:vpc" in tags
+        assert "git_branch:main" in tags
+        assert "git_commit:abc123d" in tags
+
+    def test_tags_omit_git_context_when_absent(self):
+        h = self._make_handler()
+        p = h._build_payload(
+            TerraformAction.APPLY,
+            self._defn(),
+            "prod-use1",
+            self._git_info(branch="", short_commit=""),
+        )
+        tags = p["data"]["attributes"]["tags"]
+        assert not any(t.startswith("git_branch:") for t in tags)
+        assert not any(t.startswith("git_commit:") for t in tags)
+
+    def test_change_metadata_omits_empty_values(self):
+        h = self._make_handler()
+        p = h._build_payload(
+            TerraformAction.APPLY,
+            self._defn(),
+            "prod-use1",
+            self._git_info(branch="", subject=""),
+        )
+        meta = self._attrs(p)["change_metadata"]
+        assert "branch" not in meta
+        assert "commit_subject" not in meta
+        assert meta["commit_sha"] == "abc123def456"
+        assert meta["commit_short_sha"] == "abc123d"
+        assert meta["category"] == "prod"
+        assert meta["env"] == "use1"
+        assert meta["action"] == "apply"
+
+    def test_change_metadata_includes_definition_dump(self):
+        h = self._make_handler()
+        p = h._build_payload(
+            TerraformAction.APPLY, self._defn(), "prod-use1", self._git_info()
+        )
+        meta = self._attrs(p)["change_metadata"]
+        assert meta["definition"]["name"] == "vpc"
+
+
+class TestDatadogExecute:
+    def _make_handler(self):
+        from tfworker.handlers.datadog import DatadogConfig, DatadogHandler
+
+        h = DatadogHandler(DatadogConfig(**_RAW_KEYS))
+        h._http = MagicMock()
+        h._http.request.return_value = MagicMock(status=202, data=b"{}")
+        return h
+
+    def _defn(self, name="vpc"):
+        return Definition(name=name, path="/tmp")
+
+    def test_apply_success_posts_event(self):
+        h = self._make_handler()
+        with patch.object(h, "_resolve_git_info", return_value={}):
+            with patch.object(h, "_build_payload", return_value={"data": {}}):
+                h.execute(
+                    TerraformAction.APPLY,
+                    TerraformStage.POST,
+                    "prod-use1",
+                    self._defn(),
+                    "/tmp",
+                    TerraformResult(0, b"ok", b""),
+                )
+        h._http.request.assert_called_once()
+
+    def test_destroy_success_posts_event(self):
+        h = self._make_handler()
+        with patch.object(h, "_resolve_git_info", return_value={}):
+            with patch.object(h, "_build_payload", return_value={"data": {}}):
+                h.execute(
+                    TerraformAction.DESTROY,
+                    TerraformStage.POST,
+                    "prod-use1",
+                    self._defn(),
+                    "/tmp",
+                    TerraformResult(0, b"ok", b""),
+                )
+        h._http.request.assert_called_once()
+
+    def test_plan_does_not_post(self):
+        h = self._make_handler()
+        h.execute(
+            TerraformAction.PLAN,
+            TerraformStage.POST,
+            "prod-use1",
+            self._defn(),
+            "/tmp",
+            TerraformResult(0, b"ok", b""),
+        )
+        h._http.request.assert_not_called()
+
+    def test_pre_stage_does_not_post(self):
+        h = self._make_handler()
+        h.execute(
+            TerraformAction.APPLY,
+            TerraformStage.PRE,
+            "prod-use1",
+            self._defn(),
+            "/tmp",
+            None,
+        )
+        h._http.request.assert_not_called()
+
+    def test_failed_apply_does_not_post(self):
+        h = self._make_handler()
+        h.execute(
+            TerraformAction.APPLY,
+            TerraformStage.POST,
+            "prod-use1",
+            self._defn(),
+            "/tmp",
+            TerraformResult(1, b"", b"boom"),
+        )
+        h._http.request.assert_not_called()
+
+    def test_none_result_does_not_post(self):
+        h = self._make_handler()
+        h.execute(
+            TerraformAction.APPLY,
+            TerraformStage.POST,
+            "prod-use1",
+            self._defn(),
+            "/tmp",
+            None,
+        )
+        h._http.request.assert_not_called()
+
+    def test_post_sends_credential_headers_and_json_body(self):
+        h = self._make_handler()
+        with patch.object(h, "_resolve_git_info", return_value={}):
+            with patch.object(h, "_build_payload", return_value={"data": {"x": 1}}):
+                h.execute(
+                    TerraformAction.APPLY,
+                    TerraformStage.POST,
+                    "prod-use1",
+                    self._defn(),
+                    "/tmp",
+                    TerraformResult(0, b"ok", b""),
+                )
+        args, kwargs = h._http.request.call_args
+        assert args[0] == "POST"
+        assert args[1].endswith("/api/v2/events")
+        assert kwargs["headers"]["DD-API-KEY"] == "placeholder-api-key"
+        assert kwargs["headers"]["DD-APP-KEY"] == "placeholder-app-key"
+        assert json.loads(kwargs["body"].decode()) == {"data": {"x": 1}}
+
+
+class TestDatadogPostErrors:
+    """The handler no longer raises on post failures; it warns and continues so
+    a Datadog outage never aborts a terraform run."""
+
+    def _make_handler(self):
+        from tfworker.handlers.datadog import DatadogConfig, DatadogHandler
+
+        h = DatadogHandler(DatadogConfig(**_RAW_KEYS))
+        h._http = MagicMock()
+        return h
+
+    def test_non_2xx_warns_and_does_not_raise(self):
+        h = self._make_handler()
+        h._http.request.return_value = MagicMock(status=403, data=b"forbidden")
+        with patch("tfworker.handlers.datadog.log.warn") as warn:
+            h._post_event({"data": {}})
+        warn.assert_called_once()
+        assert "403" in warn.call_args.args[0]
+
+    def test_request_exception_warns_and_does_not_raise(self):
+        h = self._make_handler()
+        h._http.request.side_effect = Exception("network down")
+        with patch("tfworker.handlers.datadog.log.warn") as warn:
+            h._post_event({"data": {}})
+        warn.assert_called_once()
+        assert "network down" in warn.call_args.args[0]
+
+    def test_2xx_does_not_warn(self):
+        h = self._make_handler()
+        h._http.request.return_value = MagicMock(status=202, data=b"{}")
+        with patch("tfworker.handlers.datadog.log.warn") as warn:
+            h._post_event({"data": {}})
+        warn.assert_not_called()
+
+
+class TestDatadogRegistry:
+    def test_registered_as_datadog(self):
+        import tfworker.handlers.datadog  # noqa: F401
+        from tfworker.handlers.datadog import DatadogHandler
+        from tfworker.handlers.registry import HandlerRegistry
+
+        assert HandlerRegistry.get_handler("datadog") is DatadogHandler
+
+    def test_config_model_is_datadog_config(self):
+        import tfworker.handlers.datadog  # noqa: F401
+        from tfworker.handlers.datadog import DatadogConfig
+        from tfworker.handlers.registry import HandlerRegistry
+
+        assert HandlerRegistry.get_handler_config_model("datadog") is DatadogConfig
+
+    def test_actions_are_apply_and_destroy(self):
+        from tfworker.handlers.datadog import DatadogHandler
+
+        assert TerraformAction.APPLY in DatadogHandler.actions
+        assert TerraformAction.DESTROY in DatadogHandler.actions
+        assert TerraformAction.PLAN not in DatadogHandler.actions

--- a/tfworker/definitions/model.py
+++ b/tfworker/definitions/model.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 import tfworker.util.log as log
 
@@ -71,7 +71,11 @@ class Definition(BaseModel):
     ready: bool = False
     needs_apply: bool = False
     plan_failed: bool = False
-    plan_file: Optional[Union[str, None]] = None
+    plan_file: Optional[Union[Path, str, None]] = None
+
+    @field_serializer("plan_file")
+    def serialize_plan_file(self, plan_file: Path | str | None):
+        return str(plan_file)
 
     def get_target_path(self, working_dir: str) -> str:
         """

--- a/tfworker/handlers/__init__.py
+++ b/tfworker/handlers/__init__.py
@@ -1,6 +1,7 @@
 from .base import BaseHandler  # pragma: no cover # noqa
 from .bitbucket import BitbucketConfig, BitbucketHandler  # pragma: no cover # noqa
 from .collection import HandlersCollection  # pragma: no cover # noqa
+from .datadog import DatadogConfig, DatadogHandler  # pragma: no cover # noqa
 from .openai import OpenAIConfig, OpenAIHandler  # pragma: no cover # noqa
 from .results import BaseHandlerResult  # pragma: no cover # noqa
 from .s3 import S3Handler  # pragma: no cover # noqa

--- a/tfworker/handlers/datadog.py
+++ b/tfworker/handlers/datadog.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 import tfworker.util.log as log
 from tfworker.custom_types.terraform import TerraformAction, TerraformStage
+from tfworker.util.system import strip_ansi
 
 from .base import BaseHandler
 from .registry import HandlerRegistry
@@ -229,8 +230,8 @@ class DatadogHandler(BaseHandler):
             tags.append(f"git_commit:{git_info['short_commit']}")
 
         is_ci = bool(os.environ.get("CI"))
-        stdout = result.stdout_str
-        stderr = result.stderr_str
+        stdout = strip_ansi(result.stdout_str)
+        stderr = strip_ansi(result.stderr_str)
 
         change_metadata = {
             k: v
@@ -248,8 +249,8 @@ class DatadogHandler(BaseHandler):
                 "is_ci": is_ci,
                 "executing_user": os.environ.get("USER"),
                 # Capture and truncate to DD's text limit (4096)
-                "stdout": (stdout[4000:] + '...') if len(stdout) > 4000 else stdout,
-                "stderr": (stderr[4000:] + '...') if len(stderr) > 4000 else stderr
+                "stdout": (stdout[4000:] + "...") if len(stdout) > 4000 else stdout,
+                "stderr": (stderr[4000:] + "...") if len(stderr) > 4000 else stderr,
             }.items()
             if v
         }

--- a/tfworker/handlers/datadog.py
+++ b/tfworker/handlers/datadog.py
@@ -1,0 +1,303 @@
+"""Datadog handler for terraform-worker.
+
+Posts a Datadog *change event* to the Events API (v2) after a definition is
+successfully applied or destroyed. The event records the current git context
+(branch, commit, subject) and attributes the change to the author of the most
+recent commit.
+
+Example configuration::
+
+    handlers:
+      datadog:
+        api_key: "..."              # raw value; supports jinja injection
+        app_key: "..."              # raw value; supports jinja injection
+        # api_key_env: "DD_API_KEY" # env var name (default)
+        # app_key_env: "DD_APP_KEY" # env var name (default)
+"""
+
+import json
+import os
+import subprocess
+from typing import TYPE_CHECKING, Union
+
+import urllib3
+from pydantic import BaseModel, Field, PrivateAttr, model_validator
+
+import tfworker.util.log as log
+from tfworker.custom_types.terraform import TerraformAction, TerraformStage
+
+from .base import BaseHandler
+from .registry import HandlerRegistry
+
+if TYPE_CHECKING:  # pragma: no cover
+    from tfworker.commands.terraform import TerraformResult
+    from tfworker.definitions.model import Definition
+
+
+class DatadogConfig(BaseModel):
+    """Configuration for the Datadog change-event handler."""
+
+    api_key: str | None = Field(default=None, repr=False)
+    app_key: str | None = Field(default=None, repr=False)
+    api_key_env: str = "DD_API_KEY"
+    app_key_env: str = "DD_APP_KEY"
+
+    _resolved_api_key: str = PrivateAttr(default="")
+    _resolved_app_key: str = PrivateAttr(default="")
+
+    @model_validator(mode="after")
+    def resolve_credentials(self) -> "DatadogConfig":
+        if self.api_key:
+            self._resolved_api_key = self.api_key
+        else:
+            env_key = os.environ.get(self.api_key_env)
+            if not env_key:
+                raise ValueError(
+                    f"Datadog API key not found: set env var '{self.api_key_env}' "
+                    "or provide 'api_key' in handler config"
+                )
+            self._resolved_api_key = env_key
+
+        if self.app_key:
+            self._resolved_app_key = self.app_key
+        else:
+            env_key = os.environ.get(self.app_key_env)
+            if not env_key:
+                raise ValueError(
+                    f"Datadog APP key not found: set env var '{self.app_key_env}' "
+                    "or provide 'app_key' in handler config"
+                )
+            self._resolved_app_key = env_key
+        return self
+
+    @property
+    def resolved_api_key(self) -> str:
+        return self._resolved_api_key
+
+    @property
+    def resolved_app_key(self) -> str:
+        return self._resolved_app_key
+
+    @property
+    def events_url(self) -> str:
+        return "https://event-management-intake.datadoghq.com/api/v2/events"
+
+
+@HandlerRegistry.register("datadog")
+class DatadogHandler(BaseHandler):
+    """Post a Datadog change event after a successful apply or destroy."""
+
+    actions = [TerraformAction.APPLY, TerraformAction.DESTROY]
+    config_model = DatadogConfig
+    _ready = False
+    default_priority = {
+        TerraformAction.APPLY: 110,
+        TerraformAction.DESTROY: 110,
+    }
+
+    def __init__(self, config: DatadogConfig) -> None:
+        self.config = config
+        self._http = urllib3.PoolManager()
+        self._ready = True
+
+    def is_ready(self) -> bool:
+        return self._ready
+
+    def execute(
+        self,
+        action: "TerraformAction",
+        stage: "TerraformStage",
+        deployment: str,
+        definition: "Definition",
+        working_dir: str,
+        result: Union["TerraformResult", None] = None,
+    ) -> None:
+        # Only emit on a successful apply/destroy. A "change" only happened if
+        # terraform actually completed the action without error.
+        if (
+            action not in (TerraformAction.APPLY, TerraformAction.DESTROY)
+            or stage != TerraformStage.POST
+            or result is None
+            or result.exit_code != 0
+        ):
+            return None
+
+        definition_git_info = self._resolve_git_info(
+            definition.get_target_path(working_dir)
+        )
+        payload = self._build_payload(
+            action, definition, deployment, definition_git_info
+        )
+        log.debug(f"Sending change event to Datadog: {json.dumps(payload)}")
+        self._post_event(payload)
+        return None
+
+    def _resolve_git_info(self, working_dir: str) -> dict:
+        """Collect git context for the most recent commit.
+
+        All values default to empty strings when unavailable so a
+        missing git context never aborts the run.
+        """
+        info = {
+            "branch": "",
+            "commit": "",
+            "short_commit": "",
+            "author_name": "",
+            "author_email": "",
+            "subject": "",
+        }
+
+        info["branch"] = self._git(working_dir, "rev-parse", "--abbrev-ref", "HEAD")
+
+        fields = {
+            "commit": "%H",
+            "short_commit": "%h",
+            "author_name": "%an",
+            "author_email": "%ae",
+            "subject": "%s",
+        }
+        for key, fmt in fields.items():
+            info[key] = self._git(working_dir, "log", "-1", f"--format={fmt}")
+
+        return info
+
+    @staticmethod
+    def _git(working_dir: str, *args: str) -> str:
+        """Run a git command, returning stripped stdout or '' on any failure."""
+        try:
+            return (
+                subprocess.check_output(
+                    ["git", *args],
+                    cwd=working_dir,
+                    stderr=subprocess.DEVNULL,
+                    timeout=5,
+                )
+                .decode()
+                .strip()
+            )
+        except Exception:
+            return ""
+
+    def _build_payload(
+        self,
+        action: "TerraformAction",
+        definition: "Definition",
+        deployment: str,
+        git_info: dict,
+    ) -> dict:
+        """Build a v2 Events API change-event payload."""
+        author = git_info["author_email"] or git_info["author_name"] or "unknown"
+
+        title = f"Terraform {action.value} of {deployment}/{definition.name}"
+        service = definition.name.replace("_", "-")
+
+        category, env = deployment.split("-")
+
+        message_lines = [
+            f"Terraform {action.value} completed for `{definition.name}` "
+            f"in deployment `{deployment}`.",
+        ]
+
+        if len(git_info) > 0:
+            message_lines.append("Definition Git:")
+        if git_info["subject"]:
+            message_lines.append(f"Commit: {git_info['subject']}")
+        if git_info["short_commit"]:
+            message_lines.append(f"SHA: {git_info['short_commit']}")
+        if git_info["branch"]:
+            message_lines.append(f"Branch: {git_info['branch']}")
+        if git_info["author_name"]:
+            author_email = git_info["author_email"]
+            if author_email:
+                message_lines.append(
+                    f"Author: {git_info['author_name']} <{author_email}>"
+                )
+            else:
+                message_lines.append(f"Author: {git_info['author_name']}")
+        message = "\n".join(message_lines)
+
+        tags = [
+            f"env:{env}",
+            f"definition:{definition.name}",
+            f"service:{service}",
+        ]
+        if git_info["branch"]:
+            tags.append(f"git_branch:{git_info['branch']}")
+        if git_info["short_commit"]:
+            tags.append(f"git_commit:{git_info['short_commit']}")
+
+        is_ci = bool(os.environ.get("CI"))
+        change_metadata = {
+            k: v
+            for k, v in {
+                "branch": git_info["branch"],
+                "commit_sha": git_info["commit"],
+                "commit_short_sha": git_info["short_commit"],
+                "commit_subject": git_info["subject"],
+                "category": category,
+                "env": env,
+                "action": action.value,
+                "definition": definition.model_dump(
+                    mode="json", exclude_none=True, exclude_unset=True
+                ),
+                "is_ci": is_ci,
+                "executing_user": os.environ.get("USER"),
+            }.items()
+            if v
+        }
+
+        return {
+            "data": {
+                "type": "event",
+                "attributes": {
+                    "category": "change",
+                    "title": title,
+                    "message": message,
+                    "tags": tags,
+                    "attributes": {
+                        "author": {"type": "user", "name": author},
+                        "changed_resource": {
+                            "type": "configuration",
+                            "name": definition.name,
+                        },
+                        "impacted_resources": [
+                            {
+                                "type": "service",
+                                "name": service,
+                            }
+                        ],
+                        "change_metadata": change_metadata,
+                    },
+                },
+            }
+        }
+
+    def _post_event(self, payload: dict) -> None:
+        """POST the change event to the Datadog Events API.
+
+        Honors ``config.required``: when required, any failure raises a
+        terminating ``HandlerError``; otherwise failures are logged and the run
+        continues.
+        """
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "DD-API-KEY": self.config.resolved_api_key,
+            "DD-APP-KEY": self.config.resolved_app_key,
+        }
+        try:
+            resp = self._http.request(
+                "POST",
+                self.config.events_url,
+                body=json.dumps(payload).encode("utf-8"),
+                headers=headers,
+            )
+        except Exception as e:
+            log.warn(f"Datadog Event failed to post: {e}")
+            return
+        if resp.status >= 300:
+            body = resp.data.decode("utf-8", errors="replace")
+            log.warn(f"Datadog Events API returned {resp.status}: {body}")
+            return
+
+        log.debug(f"Posted Datadog change event ({resp.status})")

--- a/tfworker/handlers/datadog.py
+++ b/tfworker/handlers/datadog.py
@@ -126,7 +126,7 @@ class DatadogHandler(BaseHandler):
             definition.get_target_path(working_dir)
         )
         payload = self._build_payload(
-            action, definition, deployment, definition_git_info
+            action, definition, deployment, result, definition_git_info
         )
         log.debug(f"Sending change event to Datadog: {json.dumps(payload)}")
         self._post_event(payload)
@@ -183,6 +183,7 @@ class DatadogHandler(BaseHandler):
         action: "TerraformAction",
         definition: "Definition",
         deployment: str,
+        result: "TerraformResult",
         git_info: dict,
     ) -> dict:
         """Build a v2 Events API change-event payload."""
@@ -228,6 +229,9 @@ class DatadogHandler(BaseHandler):
             tags.append(f"git_commit:{git_info['short_commit']}")
 
         is_ci = bool(os.environ.get("CI"))
+        stdout = result.stdout_str
+        stderr = result.stderr_str
+
         change_metadata = {
             k: v
             for k, v in {
@@ -243,6 +247,9 @@ class DatadogHandler(BaseHandler):
                 ),
                 "is_ci": is_ci,
                 "executing_user": os.environ.get("USER"),
+                # Capture and truncate to DD's text limit (4096)
+                "stdout": (stdout[4000:] + '...') if len(stdout) > 4000 else stdout,
+                "stderr": (stderr[4000:] + '...') if len(stderr) > 4000 else stderr
             }.items()
             if v
         }

--- a/tfworker/handlers/datadog.py
+++ b/tfworker/handlers/datadog.py
@@ -191,15 +191,16 @@ class DatadogHandler(BaseHandler):
         title = f"Terraform {action.value} of {deployment}/{definition.name}"
         service = definition.name.replace("_", "-")
 
-        category, env = deployment.split("-")
+        category, env = deployment.split("-", 1)
 
         message_lines = [
             f"Terraform {action.value} completed for `{definition.name}` "
             f"in deployment `{deployment}`.",
         ]
 
-        if len(git_info) > 0:
-            message_lines.append("Definition Git:")
+        if any(git_info.values()):
+            message_lines.append("Definition Git Info:")
+            message_lines.append("---------------------")
         if git_info["subject"]:
             message_lines.append(f"Commit: {git_info['subject']}")
         if git_info["short_commit"]:
@@ -275,9 +276,7 @@ class DatadogHandler(BaseHandler):
     def _post_event(self, payload: dict) -> None:
         """POST the change event to the Datadog Events API.
 
-        Honors ``config.required``: when required, any failure raises a
-        terminating ``HandlerError``; otherwise failures are logged and the run
-        continues.
+        Logs failures as warn and continues
         """
         headers = {
             "Content-Type": "application/json",
@@ -289,8 +288,9 @@ class DatadogHandler(BaseHandler):
             resp = self._http.request(
                 "POST",
                 self.config.events_url,
-                body=json.dumps(payload).encode("utf-8"),
+                json=payload,
                 headers=headers,
+                timeout=urllib3.Timeout(connect=2.0, read=5.0),
             )
         except Exception as e:
             log.warn(f"Datadog Event failed to post: {e}")

--- a/tfworker/handlers/datadog.py
+++ b/tfworker/handlers/datadog.py
@@ -83,6 +83,10 @@ class DatadogConfig(BaseModel):
     def events_url(self) -> str:
         return "https://event-management-intake.datadoghq.com/api/v2/events"
 
+    @property
+    def validate_url(self) -> str:
+        return "https://api.datadoghq.com/api/v1/validate"
+
 
 @HandlerRegistry.register("datadog")
 class DatadogHandler(BaseHandler):
@@ -90,7 +94,6 @@ class DatadogHandler(BaseHandler):
 
     actions = [TerraformAction.APPLY, TerraformAction.DESTROY]
     config_model = DatadogConfig
-    _ready = False
     default_priority = {
         TerraformAction.APPLY: 110,
         TerraformAction.DESTROY: 110,
@@ -99,9 +102,55 @@ class DatadogHandler(BaseHandler):
     def __init__(self, config: DatadogConfig) -> None:
         self.config = config
         self._http = urllib3.PoolManager()
-        self._ready = True
+        self._ready: bool | None = None  # None = not yet validated
 
     def is_ready(self) -> bool:
+        """Return True only if the API key validates and Datadog is reachable.
+
+        Validated once and cached (in self._ready); a Datadog problem never
+        aborts a terraform run -- on any failure we warn and report not-ready so
+        the handler is skipped.
+        """
+        if self._ready is not None:
+            return self._ready
+
+        headers = {
+            "Accept": "application/json",
+            "DD-API-KEY": self.config.resolved_api_key,
+        }
+        try:
+            resp = self._http.request(
+                "GET",
+                self.config.validate_url,
+                headers=headers,
+                timeout=urllib3.Timeout(connect=2.0, read=5.0),
+            )
+        except Exception as e:
+            log.warn(f"Datadog credential validation failed, handler disabled: {e}")
+            self._ready = False
+            return self._ready
+
+        if resp.status != 200:
+            body = resp.data.decode("utf-8", errors="replace")
+            log.warn(
+                f"Datadog credential validation returned {resp.status}, "
+                f"handler disabled: {body}"
+            )
+            self._ready = False
+            return self._ready
+
+        # /api/v1/validate returns {"valid": true} on success.
+        try:
+            valid = json.loads(resp.data.decode("utf-8")).get("valid", False)
+        except Exception:
+            valid = False
+        if not valid:
+            log.warn("Datadog reported credentials as invalid, handler disabled")
+            self._ready = False
+            return self._ready
+
+        log.debug("Datadog credentials validated")
+        self._ready = True
         return self._ready
 
     def execute(


### PR DESCRIPTION
This pull request adds a new handler for Datadog change events. The handler posts a change event to Datadog's Events API whenever a Terraform apply or destroy action completes successfully. The implementation gathers relevant git context for each event in addition to definition metadata.

**New Datadog handler integration:**

* Added `DatadogHandler` and `DatadogConfig` in `tfworker/handlers/datadog.py` to post change events to Datadog after successful Terraform apply or destroy actions. The handler collects git context (branch, commit, author, subject) and includes it in the event payload.
* Updated `tfworker/handlers/__init__.py` to register the new Datadog handler and its config class for use in the handlers collection.